### PR TITLE
feat: Support Jina embedding model and alternative API key for JinaCrawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,13 @@ result = query("Write a report about xxx.") # Your question here
 
 <details>
   <summary>Example (Pymilvus built-in embedding model)</summary>
+    <p> Use the built-in embedding model in Pymilvus, you can set the model name as <code>"BAAI/bge-base-en-v1.5"</code>, <code>"BAAI/bge-large-en-v1.5"</code>, <code>"jina-embeddings-v3"</code>, etc. <br/>
+    See [milvus_embedding.py](deepsearcher/embedding/milvus_embedding.py) for more details.  </p>
     <pre><code>config.set_provider_config("embedding", "MilvusEmbedding", {"model": "BAAI/bge-base-en-v1.5"})</code></pre>
+    <pre><code>config.set_provider_config("embedding", "MilvusEmbedding", {"model": "jina-embeddings-v3"})</code></pre>
+    <p> For Jina's embedding model, you need<code>JINAAI_API_KEY</code>.</p>
     <p> More details about Pymilvus: https://milvus.io/docs/embeddings.md </p>
+
 </details>
 
 <details>
@@ -206,7 +211,7 @@ result = query("Write a report about xxx.") # Your question here
 
 <details>
   <summary>Example (Jina Reader)</summary>
-    <p> Make sure you have prepared your Jina Reader API KEY as an env variable <code>JINA_API_TOKEN</code>.</p>
+    <p> Make sure you have prepared your Jina Reader API KEY as an env variable <code>JINA_API_TOKEN</code> or <code>JINAAI_API_KEY</code>.</p>
     <pre><code>config.set_provider_config("web_crawler", "JinaCrawler", {})</code></pre>
     <p> More details about Jina Reader: https://jina.ai/reader/ </p>
 </details>

--- a/deepsearcher/embedding/milvus_embedding.py
+++ b/deepsearcher/embedding/milvus_embedding.py
@@ -12,6 +12,7 @@ MILVUS_MODEL_DIM_MAP = {
     "GPTCache/paraphrase-albert-onnx": 768,
     "default": 768,  # 'GPTCache/paraphrase-albert-onnx',
     # see https://github.com/milvus-io/milvus-model/blob/4974e2d190169618a06359bcda040eaed73c4d0f/src/pymilvus/model/dense/onnx.py#L12
+    "jina-embeddings-v3": 1024, # required jina api key
 }
 
 
@@ -28,9 +29,12 @@ class MilvusEmbedding(BaseEmbedding):
             "GPTCache/paraphrase-albert-onnx",
         ]:
             self.model = model.DefaultEmbeddingFunction(**kwargs)
-
         else:
-            if model_name.startswith("BAAI/"):
+            if model_name.startswith("jina-"):
+                self.model = model.dense.JinaEmbeddingFunction(
+                    model_name, **kwargs
+                )
+            elif model_name.startswith("BAAI/"):
                 self.model = model.dense.SentenceTransformerEmbeddingFunction(
                     model_name, **kwargs
                 )

--- a/deepsearcher/loader/web_crawler/jina_crawler.py
+++ b/deepsearcher/loader/web_crawler/jina_crawler.py
@@ -9,7 +9,7 @@ from deepsearcher.loader.web_crawler.base import BaseCrawler
 class JinaCrawler(BaseCrawler):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.jina_api_token = os.getenv("JINA_API_TOKEN")
+        self.jina_api_token = os.getenv("JINA_API_TOKEN") or os.getenv("JINAAI_API_KEY")
         if not self.jina_api_token:
             raise ValueError("Missing JINA_API_TOKEN environment variable")
 


### PR DESCRIPTION
```sh
export JINAAI_API_KEY=xxx
```

Use `jina-embeddings-v3` as embedding model:

```py
config.set_provider_config("embedding", "MilvusEmbedding", {"model": "jina-embeddings-v3"})
```