### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ config = Configuration()
 # Customize your config here,
 # more configuration see the Configuration Details section below.
 config.set_provider_config("llm", "OpenAI", {"model": "gpt-4o-mini"})
-config.set_provider_config("embedding", "OpenAIEmbedding", {"model", "text-embedding-ada-002")
+config.set_provider_config("embedding", "OpenAIEmbedding", {"model", "text-embedding-ada-002"})
 init_config(config = config)
 
 # Load your local data


### PR DESCRIPTION
QuickStart has a syntax error. (unbalanced parenthesis)