### PR TITLE
in some milvus environments 'embedding' section can't be returned if search output fields is set as *

### DIFF
--- a/deepsearcher/vector_db/milvus.py
+++ b/deepsearcher/vector_db/milvus.py
@@ -114,7 +114,7 @@ class Milvus(BaseVectorDB):
                 collection_name=collection,
                 data=[vector],
                 limit=top_k,
-                output_fields=["*"],
+                output_fields=["embedding", "text", "reference", "metadata"],
                 timeout=10,
             )
 


### PR DESCRIPTION
I met this a problem which might be described in issue 96.
If I create a milvus database by docker, the results of milvus client.search function do not have 'embedding' section. Thus in milvus.py Line 123, an exception would be thrown as the 'embedding' key does not exits.
But if the milvus is created by a local file, this problem disappears. 

There might be some issue in milvus configuration, but a specific output fileds list is more safe.