### PR TITLE
Master

### DIFF
--- a/tests/test_milvus.py
+++ b/tests/test_milvus.py
@@ -3,40 +3,44 @@ import pprint
 import numpy as np
 from deepsearcher.vector_db import Milvus, RetrievalResult
 from deepsearcher.tools import log
-
+from deepsearcher.loader.splitter import Chunk
 
 class TestMilvus(unittest.TestCase):
     def test_milvus(self):
         d = 8
-        collection = "hellp_deepsearcher"
+        collection = "hello_deepsearcher"
         milvus = Milvus()
-        milvus.init_db(
+        milvus.init_collection(
             dim=d,
             collection=collection,
         )
         rng = np.random.default_rng(seed=19530)
         milvus.insert_data(
             collection=collection,
-            rows=[
+            chunks=[
                 RetrievalResult(
                     embedding=rng.random((1, d))[0],
                     text="hello world",
                     reference="local file: hi.txt",
+                    metadata={"a": 1},
                 ),
                 RetrievalResult(
                     embedding=rng.random((1, d))[0],
                     text="hello milvus",
                     reference="local file: hi.txt",
+                    metadata={"a": 1},
                 ),
                 RetrievalResult(
                     embedding=rng.random((1, d))[0],
                     text="hello deep learning",
                     reference="local file: hi.txt",
+                    metadata={"a": 1},
                 ),
                 RetrievalResult(
                     embedding=rng.random((1, d))[0],
                     text="hello llm",
                     reference="local file: hi.txt",
+                    metadata={"a": 1},
                 ),
             ],
         )
@@ -47,9 +51,9 @@ class TestMilvus(unittest.TestCase):
 
     def test_clear_collection(self):
         d = 8
-        collection = "deepsearcher"
+        collection = "hello_deepsearcher"
         milvus = Milvus()
-        milvus.init_db(
+        milvus.init_collection(
             dim=d,
             only_init_client=True,
             collection=collection,

--- a/tests/test_milvus.py
+++ b/tests/test_milvus.py
@@ -3,7 +3,6 @@ import pprint
 import numpy as np
 from deepsearcher.vector_db import Milvus, RetrievalResult
 from deepsearcher.tools import log
-from deepsearcher.loader.splitter import Chunk
 
 class TestMilvus(unittest.TestCase):
     def test_milvus(self):


### PR DESCRIPTION
I've updated test_milvus.py with the following changes:

API Alignment: Replaced init_db with init_collection and updated insert_data to accept the chunks parameter instead of rows to match the Milvus class.

Data Validation: Added a sample metadata field in each RetrievalResult. I used a dummy key-value pair ({"a": 1}) as a placeholder.

Naming Consistency: Standardized the collection name to "hello_deepsearcher" across all tests. This resolves the issue where one test used "hellp_deepsearcher" (probably a typo) and another was clearing "deepsearcher" collection. Now, both tests consistently use "hello_deepsearcher"