### PR TITLE
Add a Gemini embedding example in the README and reset the batch size for embed_chunks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ result = query("Write a report about xxx.") # Your question here
     <p> More details about Volcengine: https://www.volcengine.com/docs/82379/1302003 </p>
 </details>
 
+<details>
+  <summary>Example (Google Gemini embedding)</summary>
+    <p> Make sure you have prepared your Gemini API KEY as an env variable <code>GEMINI_API_KEY</code>.</p>
+    <pre><code>config.set_provider_config("embedding", "GeminiEmbedding", {"model": "text-embedding-004"})</code></pre>
+    <p> You need to install gemini before running, execute: <code>pip install google-genai</code>. More details about Gemini: https://ai.google.dev/gemini-api/docs </p>
+</details>
+
 #### Vector Database Configuration
 <pre><code>config.set_provider_config("vector_db", "(VectorDBName)", "(Arguments dict)")</code></pre>
 <p>The "VectorDBName" can be one of the following: ["Milvus"] (Under development)</p>

--- a/deepsearcher/embedding/gemini_embedding.py
+++ b/deepsearcher/embedding/gemini_embedding.py
@@ -46,6 +46,10 @@ class GeminiEmbedding(BaseEmbedding):
         self.model = model
         self.client = genai.Client(api_key=api_key, **kwargs)
 
+    def embed_chunks(self, chunks, batch_size: int = 100):
+        # For Gemini free level, the maximum rqeusts in one batch is 100, so set the default batch size to 100
+        return super().embed_chunks(chunks, batch_size)
+
     def _get_dim(self):
         """
         Get the dimension of the embedding model.
@@ -102,12 +106,8 @@ class GeminiEmbedding(BaseEmbedding):
         Returns:
             List[List[float]]: A list of embedding vectors, one for each input text.
         """
-        # For Gemini free level, the maximum rqeusts in one batch is 100, so we need to split the texts again
-        sub_splits = [texts[i : i + 100] for i in range(0, len(texts), 100)]
-        embeddings = []
-        for texts in sub_splits:
-            result = self._embed_content(texts)
-            embeddings.extend([r.values for r in result])
+        result = self._embed_content(texts)
+        embeddings = [r.values for r in result]
         return embeddings
 
     @property


### PR DESCRIPTION
- add a Gemini embedding example in the README;
- remove the sub-split codes in `embed_documents` of `GeminiEmbedding` class, and reset the default batch size for `embed_chunks`;
- add the Signed-off-by line.