### PR TITLE
Improve the robustness of LLM generated indexes.

### DIFF
--- a/deepsearcher/agent/chain_of_rag.py
+++ b/deepsearcher/agent/chain_of_rag.py
@@ -192,7 +192,11 @@ class ChainOfRAG(RAGAgent):
                 ]
             )
             supported_doc_indices = self.llm.literal_eval(chat_response.content)
-            supported_retrieved_results = [retrieved_results[i] for i in supported_doc_indices]
+            supported_retrieved_results = [
+                retrieved_results[int(i)]
+                for i in supported_doc_indices
+                if int(i) < len(retrieved_results)
+            ]
             token_usage = chat_response.total_tokens
         return supported_retrieved_results, token_usage
 


### PR DESCRIPTION
The supported_doc_indices is parsed from the results generated by LLM, it may raise a "list index out of range" error or not be an integer.
<img width="970" alt="20250320181741" src="https://github.com/user-attachments/assets/4d3d388a-aa24-4124-974e-42753144d2ce" />
