### PR TITLE
Fix: Pass headers correctly to Ollama Client to prevent 401 Unauthorized errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,12 @@ result = query("Write a report about xxx.") # Your question here
 </details>
 
 
+<details>
+  <summary>Example (FastEmbed embedding)</summary>
+    <pre><code>config.set_provider_config("embedding", "FastEmbedEmbedding", {"model": "intfloat/multilingual-e5-large"})</code></pre>
+    <p> You need to install fastembed before running, execute: <code>pip install fastembed</code>. More details about fastembed: https://github.com/qdrant/fastembed </p>
+</details>
+
 #### Vector Database Configuration
 <pre><code>config.set_provider_config("vector_db", "(VectorDBName)", "(Arguments dict)")</code></pre>
 <p>The "VectorDBName" can be one of the following: ["Milvus"] (Under development)</p>

--- a/deepsearcher/embedding/ollama_embedding.py
+++ b/deepsearcher/embedding/ollama_embedding.py
@@ -45,7 +45,7 @@ class OllamaEmbedding(BaseEmbedding):
         else:
             dimension = OLLAMA_MODEL_DIM_MAP[model]
         self.dim = dimension
-        self.client = Client(host=base_url)
+        self.client = Client(host=base_url, **kwargs)
         self.batch_size = batch_size
 
     def embed_query(self, text: str) -> List[float]:


### PR DESCRIPTION
This pull request fixes a bug where custom headers were not being passed to the Ollama Client  during embedding initialization. Without passing these headers, attempts to connect to Ollama servers requiring authorization failed with the following error `ollama._types.ResponseError: Unauthorized (status code: 401)`
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/runpy.py", line 198, in _run_module_as_main
    return _run_code(code, main_globals, None,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/runpy.py", line 88, in _run_code
    exec(code, run_globals)
  File "/root/.vscode-server/extensions/ms-python.debugpy-2025.8.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 71, in <module>
    cli.main()
  File "/root/.vscode-server/extensions/ms-python.debugpy-2025.8.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 501, in main
    run()
  File "/root/.vscode-server/extensions/ms-python.debugpy-2025.8.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 351, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/root/.vscode-server/extensions/ms-python.debugpy-2025.8.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 310, in run_path
    return _run_module_code(code, init_globals, run_name, pkg_name=pkg_name, script_name=fname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.vscode-server/extensions/ms-python.debugpy-2025.8.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 127, in _run_module_code
    _run_code(code, mod_globals, init_globals, mod_name, mod_spec, pkg_name, script_name)
  File "/root/.vscode-server/extensions/ms-python.debugpy-2025.8.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 118, in _run_code
    exec(code, run_globals)
  File "./deep_search.py", line 95, in <module>
    load_from_local_files(
  File "/usr/local/lib/python3.11/site-packages/deepsearcher/offline_loading.py", line 68, in load_from_local_files
    chunks = embedding_model.embed_chunks(chunks, batch_size=batch_size)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/deepsearcher/embedding/base.py", line 62, in embed_chunks
    batch_embeddings = self.embed_documents(batch_text)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/deepsearcher/embedding/ollama_embedding.py", line 87, in embed_documents
    batch_embeddings = self._embed_input(batch_text)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/deepsearcher/embedding/ollama_embedding.py", line 106, in _embed_input
    response = self.client.embed(model=self.model, input=input)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ollama/_client.py", line 357, in embed
    return self._request(
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ollama/_client.py", line 178, in _request
    return cls(**self._request_raw(*args, **kwargs).json())
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ollama/_client.py", line 122, in _request_raw
    raise ResponseError(e.response.text, e.response.status_code) from None
ollama._types.ResponseError: Unauthorized (status code: 401)
```
This issue occurs when connecting to an Ollama server that requires authentication headers, such as:

```
config.set_provider_config(
    "embedding",
    "OllamaEmbedding",
    {
        "model": "bge-m3",
        "base_url": "https://ollama-instance-example.de",
        "headers": {
            "Authorization": "Bearer sk-ollama-some-key",
            "model": "bge-m3",
        },
    },
)
```
Changes included:

- Properly forwarding headers (and any additional kwargs) to the Client initialization to support authenticated requests.
- Updating README.md with an example demonstrating the use of FastEmbed with Ollama embeddings, including header configuration.

This fix enables secure and authorized communication with Ollama embedding servers that require custom headers.