### PR TITLE
Adding support for IBM watsonx.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ result = query("Write a report about xxx.") # Your question here
     <p> You need to install boto3 before running, execute: <code>pip install boto3</code>. More details about Amazon Bedrock: https://docs.aws.amazon.com/bedrock/ </p>
 </details>
 
+<details>
+  <summary>Example (IBM watsonx.ai)</summary>
+    <p> Make sure you have prepared your watsonx.ai credentials as env variables <code>WATSONX_APIKEY</code>, <code>WATSONX_URL</code>, and <code>WATSONX_PROJECT_ID</code>.</p>
+    <pre><code>config.set_provider_config("llm", "watsonx", {"model": "us.deepseek.r1-v1:0"})</code></pre>
+    <p> You need to install ibm-watsonx-ai before running, execute: <code>pip install ibm-watsonx-ai</code>. More details about IBM watsonx.ai: https://www.ibm.com/products/watsonx-ai/foundation-models </p>
+</details>
 
 
 #### Embedding Model Configuration
@@ -306,6 +312,15 @@ result = query("Write a report about xxx.") # Your question here
   <summary>Example (FastEmbed embedding)</summary>
     <pre><code>config.set_provider_config("embedding", "FastEmbedEmbedding", {"model": "intfloat/multilingual-e5-large"})</code></pre>
     <p> You need to install fastembed before running, execute: <code>pip install fastembed</code>. More details about fastembed: https://github.com/qdrant/fastembed </p>
+</details>
+
+
+<details>
+  <summary>Example (IBM watsonx.ai embedding)</summary>
+    <p> Make sure you have prepared your WatsonX credentials as env variables <code>WATSONX_APIKEY</code>, <code>WATSONX_URL</code>, and <code>WATSONX_PROJECT_ID</code>.</p>
+    <pre><code>config.set_provider_config("embedding", "WatsonXEmbedding", {"model": "ibm/slate-125m-english-rtrvr-v2"})</code></pre>
+    <pre><code>config.set_provider_config("embedding", "WatsonXEmbedding", {"model": "sentence-transformers/all-minilm-l6-v2"})</code></pre>
+    <p> You need to install ibm-watsonx-ai before running, execute: <code>pip install ibm-watsonx-ai</code>. More details about IBM watsonx.ai: https://www.ibm.com/products/watsonx-ai/foundation-models </p>
 </details>
 
 #### Vector Database Configuration
@@ -530,6 +545,7 @@ nest_asyncio.apply()
 - [FastEmbed](https://qdrant.github.io/fastembed/)
 - [PPIO](https://ppinfra.com/model-api/product/llm-api?utm_source=github_deep-searcher) (`PPIO_API_KEY` env variable required)
 - [Novita AI](https://novita.ai/docs/api-reference/model-apis-llm-create-embeddings?utm_source=github_deep-searcher&utm_medium=github_readme&utm_campaign=link) (`NOVITA_API_KEY` env variable required)
+- [IBM watsonx.ai](https://www.ibm.com/products/watsonx-ai/foundation-models#ibmembedding) (`WATSONX_APIKEY`, `WATSONX_URL`, `WATSONX_PROJECT_ID` env variables required)
 
 ### 🔹 LLM Support
 - [OpenAI](https://platform.openai.com/docs/models) (`OPENAI_API_KEY` env variable required)
@@ -543,6 +559,7 @@ nest_asyncio.apply()
 - [SambaNova Cloud Inference Service](https://docs.together.ai/docs/introduction) (`SAMBANOVA_API_KEY` env variable required)
 - [Ollama](https://ollama.com/)
 - [Novita AI](https://novita.ai/docs/guides/introduction?utm_source=github_deep-searcher&utm_medium=github_readme&utm_campaign=link) (`NOVITA_API_KEY` env variable required)
+- [IBM watsonx.ai](https://www.ibm.com/products/watsonx-ai/foundation-models#ibmfm) (`WATSONX_APIKEY`, `WATSONX_URL`, `WATSONX_PROJECT_ID` env variable required)
 
 ### 🔹 Document Loader
 - Local File

--- a/deepsearcher/embedding/__init__.py
+++ b/deepsearcher/embedding/__init__.py
@@ -11,6 +11,7 @@ from .sentence_transformer_embedding import SentenceTransformerEmbedding
 from .siliconflow_embedding import SiliconflowEmbedding
 from .volcengine_embedding import VolcengineEmbedding
 from .voyage_embedding import VoyageEmbedding
+from .watsonx_embedding import WatsonXEmbedding
 
 __all__ = [
     "MilvusEmbedding",
@@ -26,4 +27,5 @@ __all__ = [
     "FastEmbedEmbedding",
     "NovitaEmbedding",
     "SentenceTransformerEmbedding",
+    "WatsonXEmbedding",
 ]

--- a/deepsearcher/embedding/watsonx_embedding.py
+++ b/deepsearcher/embedding/watsonx_embedding.py
@@ -283,7 +283,7 @@ class WatsonXEmbedding(BaseEmbedding):
             response = self.client.embed_documents(texts=truncated_texts)
             return response
         except Exception as e:
-                raise RuntimeError(f"Error embedding documents with WatsonX: {str(e)}")
+            raise RuntimeError(f"Error embedding documents with WatsonX: {str(e)}")
 
     def _embed_documents_individually(self, texts: List[str]) -> List[List[float]]:
         """

--- a/deepsearcher/embedding/watsonx_embedding.py
+++ b/deepsearcher/embedding/watsonx_embedding.py
@@ -1,0 +1,329 @@
+import logging
+import os
+from typing import List
+
+from deepsearcher.embedding.base import BaseEmbedding
+
+try:
+    from ibm_watsonx_ai import Credentials
+    from ibm_watsonx_ai.foundation_models import Embeddings
+except ImportError:
+    Credentials = None
+    Embeddings = None
+
+try:
+    from transformers import AutoTokenizer
+
+    TRANSFORMERS_AVAILABLE = True
+except ImportError:
+    TRANSFORMERS_AVAILABLE = False
+
+# Set up logging
+logger = logging.getLogger(__name__)
+
+
+class WatsonXEmbedding(BaseEmbedding):
+    """
+    IBM watsonx.ai embedding model implementation.
+
+    This class provides an interface to the IBM watsonx.ai embedding API, which offers
+    various embedding models for text processing. It automatically handles text truncation
+    to fit within the model's token limits.
+
+    For more information, see:
+    https://www.ibm.com/products/watsonx-ai/foundation-models#ibmembedding
+    """
+
+    def __init__(self, model: str = "ibm/slate-125m-english-rtrvr-v2", **kwargs):
+        """
+        Initialize the watsonx.ai embedding model.
+
+        Args:
+            model (str): The model identifier to use for embeddings.
+                        Default is "ibm/slate-125m-english-rtrvr-v2".
+            **kwargs: Additional keyword arguments for WatsonX configuration.
+                - url (str): WatsonX endpoint URL
+                - project_id (str): WatsonX project ID
+                - space_id (str): WatsonX deployment space ID (alternative to project_id)
+                - max_tokens (int): Maximum number of tokens per text (default: 480)
+                - use_tokenizer (bool): Whether to use HuggingFace tokenizer for precise counting (default: True)
+
+        Environment Variables:
+            WATSONX_APIKEY: IBM Cloud API key for authentication
+            WATSONX_URL: WatsonX service endpoint URL
+            WATSONX_PROJECT_ID: WatsonX project ID (if not provided in kwargs)
+        """
+        if Credentials is None or Embeddings is None:
+            raise ImportError(
+                "WatsonX embedding requires ibm-watsonx-ai. "
+                "Install it with: pip install ibm-watsonx-ai"
+            )
+
+        self.model = model
+        # Set max tokens to 480 to leave more room for start/end tokens and safety margin (model limit is 512)
+        self.max_tokens = kwargs.pop("max_tokens", 480)
+        self.use_tokenizer = kwargs.pop("use_tokenizer", True) and TRANSFORMERS_AVAILABLE
+
+        # Initialize tokenizer if available and requested
+        self.tokenizer = None
+        if self.use_tokenizer:
+            try:
+                # Use a general-purpose tokenizer for token counting
+                # BERT tokenizer is a good default for most models
+                self.tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+                logger.info("Using HuggingFace tokenizer for precise token counting")
+            except Exception as e:
+                logger.warning(
+                    f"Failed to load tokenizer, falling back to character-based estimation: {e}"
+                )
+                self.use_tokenizer = False
+
+        # Get credentials from environment or kwargs
+        api_key = kwargs.pop("api_key", os.getenv("WATSONX_APIKEY"))
+        url = kwargs.pop("url", os.getenv("WATSONX_URL"))
+        project_id = kwargs.pop("project_id", os.getenv("WATSONX_PROJECT_ID"))
+        space_id = kwargs.pop("space_id", None)
+
+        if not api_key:
+            raise ValueError("WATSONX_APIKEY environment variable or api_key parameter is required")
+        if not url:
+            raise ValueError("WATSONX_URL environment variable or url parameter is required")
+        if not project_id and not space_id:
+            raise ValueError(
+                "WATSONX_PROJECT_ID environment variable, project_id or space_id parameter is required"
+            )
+
+        # Set up credentials
+        credentials = Credentials(url=url, api_key=api_key)
+
+        # Initialize the embeddings client
+        if project_id:
+            self.client = Embeddings(
+                model_id=self.model, credentials=credentials, project_id=project_id
+            )
+        else:
+            self.client = Embeddings(
+                model_id=self.model, credentials=credentials, space_id=space_id
+            )
+
+        # Get dimension for this model
+        self.dim = self._get_dim()
+
+    def _get_dim(self):
+        """
+        Get the dimensionality of embeddings for the current model.
+
+        Returns:
+            int: The number of dimensions in the embedding vectors.
+        """
+        # Common WatsonX embedding model dimensions
+        model_dimensions = {
+            "ibm/granite-embedding-278m-multilingual": 768,
+            "ibm/granite-embedding-107m-multilingual": 384,
+            "ibm/slate-125m-english-rtrvr-v2": 768,
+            "ibm/slate-125m-english-rtrvr": 768,
+            "ibm/slate-30m-english-rtrvr-v2": 384,
+            "ibm/slate-30m-english-rtrvr": 384,
+            "sentence-transformers/all-minilm-l6-v2": 384,
+            "sentence-transformers/all-minilm-l12-v2": 384,
+            "sentence-transformers/all-mpnet-base-v2": 768,
+        }
+
+        return model_dimensions.get(self.model, 768)  # Default to 768
+
+    def _count_tokens(self, text: str) -> int:
+        """
+        Count the number of tokens in the text.
+
+        Args:
+            text (str): The input text.
+
+        Returns:
+            int: The number of tokens.
+        """
+        if self.use_tokenizer and self.tokenizer:
+            return len(self.tokenizer.encode(text, add_special_tokens=False))
+        else:
+            # Fallback: rough estimation using word count
+            # For most languages, token count is roughly word count * 1.3
+            words = len(text.split())
+            return int(words * 1.3)
+
+    def _truncate_text(self, text: str) -> str:
+        """
+        Truncate text to fit within the model's token limit.
+
+        Args:
+            text (str): The input text to truncate.
+
+        Returns:
+            str: The truncated text.
+        """
+        if not text:
+            return text
+
+        # First check if truncation is needed
+        token_count = self._count_tokens(text)
+        if token_count <= self.max_tokens:
+            return text
+
+        logger.debug(
+            f"Text exceeds {self.max_tokens} tokens (actual: {token_count}), truncating..."
+        )
+
+        if self.use_tokenizer and self.tokenizer:
+            # Use tokenizer for precise truncation
+            tokens = self.tokenizer.encode(text, add_special_tokens=False)
+            if len(tokens) > self.max_tokens:
+                truncated_tokens = tokens[: self.max_tokens]
+                truncated_text = self.tokenizer.decode(truncated_tokens, skip_special_tokens=True)
+                # Double-check the token count after truncation
+                final_count = self._count_tokens(truncated_text)
+                if final_count > self.max_tokens:
+                    # If still too long, be more aggressive
+                    logger.warning(
+                        f"Aggressive truncation needed: {final_count} -> {self.max_tokens}"
+                    )
+                    truncated_tokens = tokens[: self.max_tokens - 10]  # Extra safety margin
+                    truncated_text = self.tokenizer.decode(
+                        truncated_tokens, skip_special_tokens=True
+                    )
+                return truncated_text
+                return text
+        else:
+            # Fallback: character-based truncation with word boundary respect
+            # Be more conservative: 3 characters per token for safety
+            max_chars = self.max_tokens * 3
+
+            if len(text) <= max_chars:
+                return text
+
+            # Truncate and try to end at a word boundary
+            truncated = text[:max_chars]
+
+            # Find the last space to avoid cutting words in half
+            last_space = truncated.rfind(" ")
+            if last_space > max_chars * 0.7:  # More conservative threshold
+                truncated = truncated[:last_space]
+
+            # Double-check with token counting
+            final_count = self._count_tokens(truncated)
+            if final_count > self.max_tokens:
+                # If still too long, be more aggressive
+                logger.warning(
+                    f"Fallback aggressive truncation needed: {final_count} -> {self.max_tokens}"
+                )
+                # Reduce by 20% and try again
+                max_chars = int(max_chars * 0.8)
+                truncated = text[:max_chars]
+                last_space = truncated.rfind(" ")
+                if last_space > max_chars * 0.7:
+                    truncated = truncated[:last_space]
+
+            return truncated
+
+    def embed_query(self, text: str) -> List[float]:
+        """
+        Embed a single query text.
+
+        Args:
+            text (str): The query text to embed.
+
+        Returns:
+            List[float]: A list of floats representing the embedding vector.
+        """
+        try:
+            # Truncate text if it's too long
+            truncated_text = self._truncate_text(text)
+            if len(truncated_text) != len(text):
+                logger.warning(
+                    f"Query text was truncated from {len(text)} to {len(truncated_text)} characters"
+                )
+
+            response = self.client.embed_query([truncated_text])
+            # embed_query expects a list and returns a dict with 'results'
+            return response['results'][0]['embedding']
+        except Exception as e:
+            raise RuntimeError(f"Error embedding query with WatsonX: {str(e)}")
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """
+        Embed a list of document texts.
+
+        Args:
+            texts (List[str]): A list of document texts to embed.
+
+        Returns:
+            List[List[float]]: A list of embedding vectors, one for each input text.
+        """
+        try:
+            # Truncate all texts if they're too long. Current limit from watsonx.ai API is 512 context tokens
+            truncated_texts = []
+            truncation_count = 0
+
+            for i, text in enumerate(texts):
+                truncated_text = self._truncate_text(text)
+                if len(truncated_text) != len(text):
+                    truncation_count += 1
+                    logger.debug(
+                        f"Document {i} was truncated from {len(text)} to {len(truncated_text)} characters"
+                    )
+                truncated_texts.append(truncated_text)
+
+            if truncation_count > 0:
+                logger.warning(
+                    f"Truncated {truncation_count} out of {len(texts)} documents to fit token limits"
+                )
+
+            response = self.client.embed_documents(truncated_texts)
+            # embed_documents returns a dict with 'results' containing list of embedding objects
+            return [result['embedding'] for result in response['results']]
+        except Exception as e:
+            raise RuntimeError(f"Error embedding documents with WatsonX: {str(e)}")
+
+    def _embed_documents_individually(self, texts: List[str]) -> List[List[float]]:
+        """
+        Embed documents one by one, skipping problematic ones.
+        Args:
+            texts (List[str]): A list of document texts to embed.
+
+        Returns:
+            List[List[float]]: A list of embedding vectors, one for each input text.
+        """
+        embeddings = []
+        failed_count = 0
+
+        for i, text in enumerate(texts):
+            try:
+                # Use very conservative truncation
+                original_max = self.max_tokens
+                self.max_tokens = 350  # Very conservative limit
+                truncated_text = self._truncate_text(text)
+                self.max_tokens = original_max
+
+                # Try to embed single text using embed_query API
+                response = self.client.embed_query([truncated_text])
+                embedding = response['results'][0]['embedding']
+                embeddings.append(embedding)
+            except Exception as e:
+                failed_count += 1
+                logger.error(f"Failed to embed document {i}: {str(e)}")
+                # Use zero vector as fallback
+                zero_embedding = [0.0] * self.dimension
+                embeddings.append(zero_embedding)
+
+        if failed_count > 0:
+            logger.warning(
+                f"Failed to embed {failed_count} out of {len(texts)} documents. Using zero vectors as fallback."
+            )
+        return embeddings
+
+    @property
+    def dimension(self) -> int:
+        """
+        Get the dimensionality of the embeddings for the current model.
+
+        Returns:
+            int: The number of dimensions in the embedding vectors.
+        """
+        return self.dim

--- a/deepsearcher/llm/__init__.py
+++ b/deepsearcher/llm/__init__.py
@@ -12,6 +12,7 @@ from .ppio import PPIO
 from .siliconflow import SiliconFlow
 from .together_ai import TogetherAI
 from .volcengine import Volcengine
+from .watsonx import WatsonX
 from .xai import XAI
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "Bedrock",
     "Novita",
     "Aliyun",
+    "WatsonX",
 ]

--- a/deepsearcher/llm/watsonx.py
+++ b/deepsearcher/llm/watsonx.py
@@ -56,8 +56,12 @@ class WatsonX(BaseLLM):
         # Get credentials from environment or kwargs
         api_key = kwargs.pop("api_key", os.getenv("WATSONX_APIKEY"))
         url = kwargs.pop("url", os.getenv("WATSONX_URL"))
-        project_id = kwargs.pop("project_id", os.getenv("WATSONX_PROJECT_ID"))
+        project_id = kwargs.pop("project_id", None)
         space_id = kwargs.pop("space_id", None)
+
+        # Only get project_id from environment if neither project_id nor space_id were provided
+        if project_id is None and space_id is None:
+            project_id = os.getenv("WATSONX_PROJECT_ID")
 
         if not api_key:
             raise ValueError("WATSONX_APIKEY environment variable or api_key parameter is required")
@@ -71,14 +75,14 @@ class WatsonX(BaseLLM):
         # Set up credentials
         credentials = Credentials(url=url, api_key=api_key)
 
-        # Initialize the model inference client
-        if project_id:
+        # Initialize the model inference client - prioritize space_id if provided
+        if space_id:
             self.client = ModelInference(
-                model_id=self.model, credentials=credentials, project_id=project_id
+                model_id=self.model, credentials=credentials, space_id=space_id
             )
         else:
             self.client = ModelInference(
-                model_id=self.model, credentials=credentials, space_id=space_id
+                model_id=self.model, credentials=credentials, project_id=project_id
             )
 
         # Set up generation parameters

--- a/deepsearcher/llm/watsonx.py
+++ b/deepsearcher/llm/watsonx.py
@@ -1,0 +1,150 @@
+import os
+from typing import Dict, List
+
+from deepsearcher.llm.base import BaseLLM, ChatResponse
+
+try:
+    from ibm_watsonx_ai import Credentials
+    from ibm_watsonx_ai.foundation_models import ModelInference
+    from ibm_watsonx_ai.metanames import GenTextParamsMetaNames
+except ImportError:
+    Credentials = None
+    ModelInference = None
+    GenTextParamsMetaNames = None
+
+
+class WatsonX(BaseLLM):
+    """
+    IBM watsonx.ai large language model implementation.
+
+    This class provides an interface to the IBM watsonx.ai language models,
+    supporting various foundation models available on the watsonx.ai platform.
+
+    For more information, see:
+    https://www.ibm.com/products/watsonx-ai/foundation-models#ibmfm
+    """
+
+    def __init__(self, model: str = "ibm/granite-3-3-8b-instruct", **kwargs):
+        """
+        Initialize the WatsonX language model.
+        Args:
+            model (str): The model identifier to use.
+                        Default is "ibm/granite-3-3-8b-instruct".
+            **kwargs: Additional keyword arguments for WatsonX configuration.
+                - url (str): WatsonX endpoint URL
+                - project_id (str): WatsonX project ID
+                - space_id (str): WatsonX deployment space ID (alternative to project_id)
+                - max_new_tokens (int): Maximum number of tokens to generate
+                - temperature (float): Sampling temperature (0.0 to 1.0)
+                - top_p (float): Top-p sampling parameter
+                - top_k (int): Top-k sampling parameter
+
+        Environment Variables:
+            WATSONX_APIKEY: IBM Cloud API key for authentication
+            WATSONX_URL: WatsonX service endpoint URL
+            WATSONX_PROJECT_ID: WatsonX project ID (if not provided in kwargs)
+        """
+        super().__init__()
+
+        if Credentials is None or ModelInference is None or GenTextParamsMetaNames is None:
+            raise ImportError(
+                "WatsonX LLM requires ibm-watsonx-ai. Install it with: pip install ibm-watsonx-ai"
+            )
+
+        self.model = model
+
+        # Get credentials from environment or kwargs
+        api_key = kwargs.pop("api_key", os.getenv("WATSONX_APIKEY"))
+        url = kwargs.pop("url", os.getenv("WATSONX_URL"))
+        project_id = kwargs.pop("project_id", os.getenv("WATSONX_PROJECT_ID"))
+        space_id = kwargs.pop("space_id", None)
+
+        if not api_key:
+            raise ValueError("WATSONX_APIKEY environment variable or api_key parameter is required")
+        if not url:
+            raise ValueError("WATSONX_URL environment variable or url parameter is required")
+        if not project_id and not space_id:
+            raise ValueError(
+                "WATSONX_PROJECT_ID environment variable, project_id or space_id parameter is required"
+            )
+
+        # Set up credentials
+        credentials = Credentials(url=url, api_key=api_key)
+
+        # Initialize the model inference client
+        if project_id:
+            self.client = ModelInference(
+                model_id=self.model, credentials=credentials, project_id=project_id
+            )
+        else:
+            self.client = ModelInference(
+                model_id=self.model, credentials=credentials, space_id=space_id
+            )
+
+        # Set up generation parameters
+        self.generation_params = {
+            GenTextParamsMetaNames.MAX_NEW_TOKENS: kwargs.get("max_new_tokens", 1000),
+            GenTextParamsMetaNames.TEMPERATURE: kwargs.get("temperature", 0.1),
+            GenTextParamsMetaNames.TOP_P: kwargs.get("top_p", 1.0),
+            GenTextParamsMetaNames.TOP_K: kwargs.get("top_k", 50),
+        }
+
+    def chat(self, messages: List[Dict]) -> ChatResponse:
+        """
+        Send a chat message to the WatsonX model and get a response.
+
+        Args:
+            messages: A list of message dictionaries in the format
+                     [{"role": "system", "content": "..."}, {"role": "user", "content": "..."}]
+
+        Returns:
+            ChatResponse: A ChatResponse object containing the model's response.
+        """
+        try:
+            # Convert messages to a single prompt text
+            prompt = self._messages_to_prompt(messages)
+
+            # Generate response
+            response = self.client.generate_text(prompt=prompt, params=self.generation_params)
+
+            # Extract content and token usage
+            content = response
+
+            # WatsonX doesn't always provide token counts, so we estimate
+            # This is a rough estimation - actual implementation may vary
+            total_tokens = len(prompt.split()) + len(content.split())
+
+            return ChatResponse(content=content, total_tokens=total_tokens)
+
+        except Exception as e:
+            raise RuntimeError(f"Error generating response with WatsonX: {str(e)}")
+
+    def _messages_to_prompt(self, messages: List[Dict]) -> str:
+        """
+        Convert a list of chat messages to a single prompt string.
+
+        Args:
+            messages: List of message dictionaries with 'role' and 'content' keys.
+
+        Returns:
+            str: Formatted prompt string.
+        """
+        prompt_parts = []
+
+        for message in messages:
+            role = message.get("role", "")
+            content = message.get("content", "")
+
+            if role == "system":
+                prompt_parts.append(f"System: {content}")
+            elif role == "user":
+                prompt_parts.append(f"Human: {content}")
+            elif role == "assistant":
+                prompt_parts.append(f"Assistant: {content}")
+            else:
+                prompt_parts.append(content)
+
+        # Add final prompt for assistant response
+        prompt_parts.append("Assistant:")
+
+        return "\n\n".join(prompt_parts)

--- a/docs/configuration/embedding.md
+++ b/docs/configuration/embedding.md
@@ -24,6 +24,7 @@ config.set_provider_config("embedding", "(EmbeddingModelName)", "(Arguments dict
 | **VolcengineEmbedding** | Volcengine embedding | High throughput |
 | **NovitaEmbedding** | Novita AI embedding | Cost-effective |
 | **SentenceTransformerEmbedding** | Sentence Transfomer Embedding | Self-hosted option |
+| **IBM watsonx.ai** | Various options | IBM's Enterprise AI platform |
 
 ## 🔍 Provider Examples
 
@@ -116,3 +117,10 @@ config.set_provider_config("embedding", "VoyageEmbedding", {"model": "voyage-3"}
     config.set_provider_config("embedding", "SentenceTransformerEmbedding", {"model": "BAAI/bge-large-zh-v1.5"})
     ```
     *Requires `pip install sentence-transformers`*
+
+??? example "IBM WatsonX"
+
+    ```python
+    config.set_provider_config("embedding", "WatsonXEmbedding", {"model": "ibm/slate-125m-english-rtrvr-v2"})
+    ```
+    *Requires `pip install ibm-watsonx-ai`*

--- a/docs/configuration/llm.md
+++ b/docs/configuration/llm.md
@@ -25,6 +25,7 @@ config.set_provider_config("llm", "(LLMName)", "(Arguments dict)")
 | **GLM** | ChatGLM models | glm-4-plus |
 | **Bedrock** | Amazon Bedrock LLMs | anthropic.claude, ai21.j2 |
 | **Novita** | Novita AI models | Various options |
+| **IBM watsonx.ai** | IBM Enterprise AI platform | Various options |
 
 ## 🔍 Provider Examples
 
@@ -41,6 +42,13 @@ config.set_provider_config("llm", "OpenAI", {"model": "o1-mini"})
 config.set_provider_config("llm", "DeepSeek", {"model": "deepseek-reasoner"})
 ```
 *Requires `DEEPSEEK_API_KEY` environment variable*
+
+### IBM WatsonX
+
+```python
+config.set_provider_config("llm", "WatsonX", {"model": "ibm/granite-3-3-8b-instruct"})
+```
+*Requires `WATSONX_APIKEY`, `WATSONX_URL`, and `WATSONX_PROJECT_ID` environment variables*
 
 ## 📚 Additional Providers
 
@@ -153,3 +161,32 @@ config.set_provider_config("llm", "DeepSeek", {"model": "deepseek-reasoner"})
     *Requires `OPENAI_API_KEY` environment variable*
     
     More details about Aliyun Bailian models: [https://bailian.console.aliyun.com](https://bailian.console.aliyun.com) 
+
+??? example "IBM watsonx.ai LLM"
+
+    ```python
+    config.set_provider_config("llm", "WatsonX", {"model": "ibm/granite-3-3-8b-instruct"})
+    ```
+
+    With custom parameters:
+    ```python
+    config.set_provider_config("llm", "WatsonX", {
+        "model": "ibm/granite-3-3-8b-instruct",
+        "max_new_tokens": 1000,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "top_k": 50
+    })
+    ```
+
+    With space_id instead of project_id:
+    ```python
+    config.set_provider_config("llm", "WatsonX", {
+        "model": "ibm/granite-3-3-8b-instruct""
+    })
+    ```
+
+    *Requires `WATSONX_APIKEY`, `WATSONX_URL`, and `WATSONX_PROJECT_ID` environment variables and `pip install ibm-watsonx-ai`*
+
+    More details about WatsonX: [https://www.ibm.com/products/watsonx-ai/foundation-models](https://www.ibm.com/products/watsonx-ai/foundation-models)
+```

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -24,6 +24,7 @@ Support for various embedding models to convert text into vector representations
 | **[FastEmbed](https://qdrant.github.io/fastembed/)** | None | Fast lightweight embeddings |
 | **[PPIO](https://ppinfra.com/model-api/product/llm-api)** | `PPIO_API_KEY` | Flexible cloud embeddings |
 | **[Novita AI](https://novita.ai/docs/api-reference/model-apis-llm-create-embeddings)** | `NOVITA_API_KEY` | Rich model selection |
+| **[IBM watsonx.ai](https://www.ibm.com/products/watsonx-ai/foundation-models#ibmembedding)** | `WATSONX_APIKEY`, `WATSONX_URL`, `WATSONX_PROJECT_ID` | IBM's Enterprise AI platform |
 
 ## 🧠 Large Language Models {#llm-support}
 
@@ -42,6 +43,7 @@ Support for various large language models (LLMs) to process queries and generate
 | **[SambaNova](https://docs.together.ai/docs/introduction)** | `SAMBANOVA_API_KEY` | High-performance AI platform |
 | **[Ollama](https://ollama.com/)** | None | Local LLM deployment |
 | **[Novita AI](https://novita.ai/docs/guides/introduction)** | `NOVITA_API_KEY` | Diverse AI services |
+| **[IBM watsonx.ai](https://www.ibm.com/products/watsonx-ai/foundation-models#ibmfm)** | `WATSONX_APIKEY`, `WATSONX_URL`, `WATSONX_PROJECT_ID` | IBM's Enterprise AI platform |
 
 ## 📄 Document Loader {#document-loader}
 

--- a/examples/basic_watsonx_example.py
+++ b/examples/basic_watsonx_example.py
@@ -1,0 +1,126 @@
+"""
+Example usage of WatsonX embedding and LLM in DeepSearcher.
+
+This example demonstrates how to configure and use IBM WatsonX
+embedding models and language models with DeepSearcher.
+"""
+
+import os
+from deepsearcher.configuration import Configuration
+
+def main():
+    """Example of using WatsonX with DeepSearcher."""
+
+    # Initialize configuration
+    config = Configuration()
+
+    # Set up environment variables (alternatively, set these in your shell)
+    # os.environ["WATSONX_APIKEY"] = "your-watsonx-api-key"
+    # os.environ["WATSONX_URL"] = "https://your-watsonx-instance.com"
+    # os.environ["WATSONX_PROJECT_ID"] = "your-project-id"
+
+    # Example 1: Configure WatsonX Embedding
+    print("=== WatsonX Embedding Configuration ===")
+
+    # Basic configuration with default model
+    config.set_provider_config("embedding", "WatsonXEmbedding", {})
+
+    # Configuration with custom model
+    config.set_provider_config("embedding", "WatsonXEmbedding", {
+        "model": "ibm/slate-125m-english-rtrvr-v2"
+    })
+
+    # Configuration with explicit credentials
+    # config.set_provider_config("embedding", "WatsonXEmbedding", {
+    #     "model": "sentence-transformers/all-minilm-l6-v2",
+    #     "api_key": "your-api-key",
+    #     "url": "https://your-watsonx-instance.com",
+    #     "project_id": "your-project-id"
+    # })
+
+    print("WatsonX Embedding configured successfully!")
+
+    # Example 2: Configure WatsonX LLM
+    print("\n=== WatsonX LLM Configuration ===")
+
+    # Basic configuration with default model
+    config.set_provider_config("llm", "WatsonX", {})
+
+    # Configuration with custom model and parameters
+    config.set_provider_config("llm", "WatsonX", {
+        "model": "ibm/granite-3-3-8b-instruct",
+        "max_new_tokens": 1000,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "top_k": 50
+    })
+
+    # Configuration with IBM Granite model
+    config.set_provider_config("llm", "WatsonX", {
+        "model": "ibm/granite-3-3-8b-instruct",
+        "max_new_tokens": 512,
+        "temperature": 0.1
+    })
+
+    print("WatsonX LLM configured successfully!")
+
+    # Example 3: Test embedding functionality
+    print("\n=== Testing WatsonX Embedding ===")
+    try:
+        from deepsearcher.embedding.watsonx_embedding import WatsonXEmbedding
+
+        # Check if environment variables are set
+        if all(os.getenv(var) for var in ["WATSONX_APIKEY", "WATSONX_URL", "WATSONX_PROJECT_ID"]):
+            embedding = WatsonXEmbedding()
+
+            # Test single query embedding
+            query = "What is artificial intelligence?"
+            query_embedding = embedding.embed_query(query)
+            print(f"Query embedding dimension: {len(query_embedding)}")
+
+            # Test document embeddings
+            documents = [
+                "Artificial intelligence is a branch of computer science.",
+                "Machine learning is a subset of AI.",
+                "Deep learning uses neural networks."
+            ]
+            doc_embeddings = embedding.embed_documents(documents)
+            print(f"Document embeddings: {len(doc_embeddings)} vectors of dimension {len(doc_embeddings[0])}")
+
+        else:
+            print("Environment variables not set. Skipping embedding test.")
+
+    except ImportError:
+        print("WatsonX dependencies not installed. Run: pip install ibm-watsonx-ai")
+    except Exception as e:
+        print(f"Error testing embedding: {e}")
+
+    # Example 4: Test LLM functionality
+    print("\n=== Testing WatsonX LLM ===")
+    try:
+        from deepsearcher.llm.watsonx import WatsonX
+
+        # Check if environment variables are set
+        if all(os.getenv(var) for var in ["WATSONX_APIKEY", "WATSONX_URL", "WATSONX_PROJECT_ID"]):
+            llm = WatsonX()
+
+            # Test chat functionality
+            messages = [
+                {"role": "system", "content": "You are a helpful AI assistant."},
+                {"role": "user", "content": "Explain what artificial intelligence is in one sentence."}
+            ]
+
+            response = llm.chat(messages)
+            print(f"LLM Response: {response.content}")
+            print(f"Tokens used: {response.total_tokens}")
+
+        else:
+            print("Environment variables not set. Skipping LLM test.")
+
+    except ImportError:
+        print("WatsonX dependencies not installed. Run: pip install ibm-watsonx-ai")
+    except Exception as e:
+        print(f"Error testing LLM: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "argparse>=1.4.0",
     "fastapi>=0.115.12",
     "firecrawl-py>=2.5.3",
+    "ibm-watsonx-ai>=1.3.0",
     "langchain-text-splitters>=0.3.8",
     "numpy>=1.26.4",
     "openai>=1.77.0",
@@ -59,6 +60,7 @@ all = [
     "docling-core>=2.30.0",
     "crawl4ai>=0.6.2",
     "sentence-transformers>=4.1.0",
+    "ibm-watsonx-ai>=1.3.0"
 ]
 
 voyageai = [
@@ -108,6 +110,9 @@ sentence-transformers = [
     "sentence-transformers>=4.1.0",
 ]
 
+ibm-watsonx = [
+    "ibm-watsonx-ai>=1.3.0"
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/embedding/test_watsonx_embedding.py
+++ b/tests/embedding/test_watsonx_embedding.py
@@ -1,0 +1,288 @@
+import unittest
+from unittest.mock import MagicMock, patch, ANY
+import os
+
+class TestWatsonXEmbedding(unittest.TestCase):
+    """Test cases for WatsonXEmbedding class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Mock the ibm_watsonx_ai imports
+        self.mock_credentials = MagicMock()
+        self.mock_embeddings = MagicMock()
+
+        # Create a mock client
+        self.mock_client = MagicMock()
+
+        # Set up mock response for embed_query
+        self.mock_client.embed_query.return_value = {
+            'results': [
+                {'embedding': [0.1] * 768}
+            ]
+        }
+
+    @patch('deepsearcher.embedding.watsonx_embedding.Embeddings')
+    @patch('deepsearcher.embedding.watsonx_embedding.Credentials')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_init_with_env_vars(self, mock_credentials_class, mock_embeddings_class):
+        """Test initialization with environment variables."""
+        from deepsearcher.embedding.watsonx_embedding import WatsonXEmbedding
+
+        mock_credentials_instance = MagicMock()
+        mock_embeddings_instance = MagicMock()
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_embeddings_class.return_value = mock_embeddings_instance
+
+        embedding = WatsonXEmbedding()
+
+        # Check that Credentials was called with correct parameters
+        mock_credentials_class.assert_called_once_with(
+            url='https://test.watsonx.com',
+            api_key='test-api-key'
+        )
+
+        # Check that Embeddings was called with correct parameters
+        mock_embeddings_class.assert_called_once_with(
+            model_id='ibm/slate-125m-english-rtrvr-v2',
+            credentials=mock_credentials_instance,
+            project_id='test-project-id'
+        )
+
+        # Check default model and dimension
+        self.assertEqual(embedding.model, 'ibm/slate-125m-english-rtrvr-v2')
+        self.assertEqual(embedding.dimension, 768)
+
+    @patch('deepsearcher.embedding.watsonx_embedding.Embeddings')
+    @patch('deepsearcher.embedding.watsonx_embedding.Credentials')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com'
+    })
+    def test_init_with_space_id(self, mock_credentials_class, mock_embeddings_class):
+        """Test initialization with space_id instead of project_id."""
+        from deepsearcher.embedding.watsonx_embedding import WatsonXEmbedding
+
+        mock_credentials_instance = MagicMock()
+        mock_embeddings_instance = MagicMock()
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_embeddings_class.return_value = mock_embeddings_instance
+
+        embedding = WatsonXEmbedding(space_id='test-space-id')
+
+        # Check that Embeddings was called with space_id
+        mock_embeddings_class.assert_called_once_with(
+            model_id='ibm/slate-125m-english-rtrvr-v2',
+            credentials=mock_credentials_instance,
+            space_id='test-space-id'
+        )
+
+    @patch('deepsearcher.embedding.watsonx_embedding.Embeddings')
+    @patch('deepsearcher.embedding.watsonx_embedding.Credentials')
+    def test_init_missing_api_key(self, mock_credentials_class, mock_embeddings_class):
+        """Test initialization with missing API key."""
+        from deepsearcher.embedding.watsonx_embedding import WatsonXEmbedding
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError) as context:
+                WatsonXEmbedding()
+
+            self.assertIn("WATSONX_APIKEY", str(context.exception))
+
+    @patch('deepsearcher.embedding.watsonx_embedding.Embeddings')
+    @patch('deepsearcher.embedding.watsonx_embedding.Credentials')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key'
+    })
+    def test_init_missing_url(self, mock_credentials_class, mock_embeddings_class):
+        """Test initialization with missing URL."""
+        from deepsearcher.embedding.watsonx_embedding import WatsonXEmbedding
+
+        with self.assertRaises(ValueError) as context:
+            WatsonXEmbedding()
+
+        self.assertIn("WATSONX_URL", str(context.exception))
+
+    @patch('deepsearcher.embedding.watsonx_embedding.Embeddings')
+    @patch('deepsearcher.embedding.watsonx_embedding.Credentials')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com'
+    })
+    def test_init_missing_project_and_space_id(self, mock_credentials_class, mock_embeddings_class):
+        """Test initialization with missing both project_id and space_id."""
+        from deepsearcher.embedding.watsonx_embedding import WatsonXEmbedding
+
+        with self.assertRaises(ValueError) as context:
+            WatsonXEmbedding()
+
+        self.assertIn("WATSONX_PROJECT_ID", str(context.exception))
+
+    @patch('deepsearcher.embedding.watsonx_embedding.Embeddings')
+    @patch('deepsearcher.embedding.watsonx_embedding.Credentials')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_embed_query(self, mock_credentials_class, mock_embeddings_class):
+        """Test embedding a single query."""
+        from deepsearcher.embedding.watsonx_embedding import WatsonXEmbedding
+
+        mock_credentials_instance = MagicMock()
+        mock_embeddings_instance = MagicMock()
+        mock_embeddings_instance.embed_query.return_value = {
+            'results': [{'embedding': [0.1] * 768}]
+        }
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_embeddings_class.return_value = mock_embeddings_instance
+
+        # Create the embedder
+        embedding = WatsonXEmbedding()
+
+        # Create a test query
+        query = "This is a test query"
+
+        # Call the method
+        result = embedding.embed_query(query)
+
+        # Verify that embed_query was called correctly
+        mock_embeddings_instance.embed_query.assert_called_once_with([query])
+
+        # Check the result
+        self.assertEqual(result, [0.1] * 768)
+
+    @patch('deepsearcher.embedding.watsonx_embedding.Embeddings')
+    @patch('deepsearcher.embedding.watsonx_embedding.Credentials')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_embed_documents(self, mock_credentials_class, mock_embeddings_class):
+        """Test embedding multiple documents."""
+        from deepsearcher.embedding.watsonx_embedding import WatsonXEmbedding
+
+        mock_credentials_instance = MagicMock()
+        mock_embeddings_instance = MagicMock()
+        mock_embeddings_instance.embed_documents.return_value = {
+            'results': [
+                {'embedding': [0.1] * 768},
+                {'embedding': [0.2] * 768},
+                {'embedding': [0.3] * 768}
+            ]
+        }
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_embeddings_class.return_value = mock_embeddings_instance
+
+        # Create the embedder
+        embedding = WatsonXEmbedding()
+
+        # Create test documents
+        documents = ["Document 1", "Document 2", "Document 3"]
+
+        # Call the method
+        results = embedding.embed_documents(documents)
+
+        # Verify that embed_documents was called correctly
+        mock_embeddings_instance.embed_documents.assert_called_once_with(documents)
+
+        # Check the results
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0], [0.1] * 768)
+        self.assertEqual(results[1], [0.2] * 768)
+        self.assertEqual(results[2], [0.3] * 768)
+
+    @patch('deepsearcher.embedding.watsonx_embedding.Embeddings')
+    @patch('deepsearcher.embedding.watsonx_embedding.Credentials')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_dimension_property(self, mock_credentials_class, mock_embeddings_class):
+        """Test the dimension property for different models."""
+        from deepsearcher.embedding.watsonx_embedding import WatsonXEmbedding
+
+        mock_credentials_instance = MagicMock()
+        mock_embeddings_instance = MagicMock()
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_embeddings_class.return_value = mock_embeddings_instance
+
+        # Test default model
+        embedding = WatsonXEmbedding()
+        self.assertEqual(embedding.dimension, 768)
+
+        # Test different model
+        embedding = WatsonXEmbedding(model='ibm/slate-30m-english-rtrvr')
+        self.assertEqual(embedding.dimension, 384)
+
+        # Test unknown model (should default to 768)
+        embedding = WatsonXEmbedding(model='unknown-model')
+        self.assertEqual(embedding.dimension, 768)
+
+    @patch('deepsearcher.embedding.watsonx_embedding.Embeddings')
+    @patch('deepsearcher.embedding.watsonx_embedding.Credentials')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_embed_query_error_handling(self, mock_credentials_class, mock_embeddings_class):
+        """Test error handling in embed_query."""
+        from deepsearcher.embedding.watsonx_embedding import WatsonXEmbedding
+
+        mock_credentials_instance = MagicMock()
+        mock_embeddings_instance = MagicMock()
+        mock_embeddings_instance.embed_query.side_effect = Exception("API Error")
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_embeddings_class.return_value = mock_embeddings_instance
+
+        # Create the embedder
+        embedding = WatsonXEmbedding()
+
+        # Test that the exception is properly wrapped
+        with self.assertRaises(RuntimeError) as context:
+            embedding.embed_query("test")
+
+        self.assertIn("Error embedding query with WatsonX", str(context.exception))
+
+    @patch('deepsearcher.embedding.watsonx_embedding.Embeddings')
+    @patch('deepsearcher.embedding.watsonx_embedding.Credentials')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_embed_documents_error_handling(self, mock_credentials_class, mock_embeddings_class):
+        """Test error handling in embed_documents."""
+        from deepsearcher.embedding.watsonx_embedding import WatsonXEmbedding
+
+        mock_credentials_instance = MagicMock()
+        mock_embeddings_instance = MagicMock()
+        mock_embeddings_instance.embed_documents.side_effect = Exception("API Error")
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_embeddings_class.return_value = mock_embeddings_instance
+
+        # Create the embedder
+        embedding = WatsonXEmbedding()
+
+        # Test that the exception is properly wrapped
+        with self.assertRaises(RuntimeError) as context:
+            embedding.embed_documents(["test"])
+
+        self.assertIn("Error embedding documents with WatsonX", str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/embedding/test_watsonx_embedding.py
+++ b/tests/embedding/test_watsonx_embedding.py
@@ -136,10 +136,8 @@ class TestWatsonXEmbedding(unittest.TestCase):
 
         mock_credentials_instance = MagicMock()
         mock_embeddings_instance = MagicMock()
-        mock_embeddings_instance.embed_query.return_value = {
-            'results': [{'embedding': [0.1] * 768}]
-        }
-
+        # WatsonX embed_query returns the embedding vector directly, not wrapped in a dict
+        mock_embeddings_instance.embed_query.return_value = [0.1] * 768
         mock_credentials_class.return_value = mock_credentials_instance
         mock_embeddings_class.return_value = mock_embeddings_instance
 
@@ -153,7 +151,7 @@ class TestWatsonXEmbedding(unittest.TestCase):
         result = embedding.embed_query(query)
 
         # Verify that embed_query was called correctly
-        mock_embeddings_instance.embed_query.assert_called_once_with([query])
+        mock_embeddings_instance.embed_query.assert_called_once_with(text=query)
 
         # Check the result
         self.assertEqual(result, [0.1] * 768)
@@ -171,14 +169,12 @@ class TestWatsonXEmbedding(unittest.TestCase):
 
         mock_credentials_instance = MagicMock()
         mock_embeddings_instance = MagicMock()
-        mock_embeddings_instance.embed_documents.return_value = {
-            'results': [
-                {'embedding': [0.1] * 768},
-                {'embedding': [0.2] * 768},
-                {'embedding': [0.3] * 768}
-            ]
-        }
-
+        # WatsonX embed_documents returns a list of embedding vectors directly
+        mock_embeddings_instance.embed_documents.return_value = [
+            [0.1] * 768,
+            [0.2] * 768,
+            [0.3] * 768
+        ]
         mock_credentials_class.return_value = mock_credentials_instance
         mock_embeddings_class.return_value = mock_embeddings_instance
 
@@ -192,7 +188,7 @@ class TestWatsonXEmbedding(unittest.TestCase):
         results = embedding.embed_documents(documents)
 
         # Verify that embed_documents was called correctly
-        mock_embeddings_instance.embed_documents.assert_called_once_with(documents)
+        mock_embeddings_instance.embed_documents.assert_called_once_with(texts=documents)
 
         # Check the results
         self.assertEqual(len(results), 3)

--- a/tests/llm/test_watsonx.py
+++ b/tests/llm/test_watsonx.py
@@ -1,0 +1,421 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import os
+
+class TestWatsonX(unittest.TestCase):
+    """Test cases for WatsonX class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        pass
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_init_with_env_vars(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test initialization with environment variables."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        mock_credentials_instance = MagicMock()
+        mock_model_inference_instance = MagicMock()
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_model_inference_class.return_value = mock_model_inference_instance
+
+        # Mock the GenTextParamsMetaNames attributes
+        mock_gen_text_params_class.MAX_NEW_TOKENS = 'max_new_tokens'
+        mock_gen_text_params_class.TEMPERATURE = 'temperature'
+        mock_gen_text_params_class.TOP_P = 'top_p'
+        mock_gen_text_params_class.TOP_K = 'top_k'
+
+        llm = WatsonX()
+
+        # Check that Credentials was called with correct parameters
+        mock_credentials_class.assert_called_once_with(
+            url='https://test.watsonx.com',
+            api_key='test-api-key'
+        )
+
+        # Check that ModelInference was called with correct parameters
+        mock_model_inference_class.assert_called_once_with(
+            model_id='ibm/granite-3-3-8b-instruct',
+            credentials=mock_credentials_instance,
+            project_id='test-project-id'
+        )
+
+        # Check default model
+        self.assertEqual(llm.model, 'ibm/granite-3-3-8b-instruct')
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com'
+    })
+    def test_init_with_space_id(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test initialization with space_id instead of project_id."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        mock_credentials_instance = MagicMock()
+        mock_model_inference_instance = MagicMock()
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_model_inference_class.return_value = mock_model_inference_instance
+
+        # Mock the GenTextParamsMetaNames attributes
+        mock_gen_text_params_class.MAX_NEW_TOKENS = 'max_new_tokens'
+        mock_gen_text_params_class.TEMPERATURE = 'temperature'
+        mock_gen_text_params_class.TOP_P = 'top_p'
+        mock_gen_text_params_class.TOP_K = 'top_k'
+
+        llm = WatsonX(space_id='test-space-id')
+
+        # Check that ModelInference was called with space_id
+        mock_model_inference_class.assert_called_once_with(
+            model_id='ibm/granite-3-3-8b-instruct',
+            credentials=mock_credentials_instance,
+            space_id='test-space-id'
+        )
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_init_with_custom_model(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test initialization with custom model."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        mock_credentials_instance = MagicMock()
+        mock_model_inference_instance = MagicMock()
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_model_inference_class.return_value = mock_model_inference_instance
+
+        # Mock the GenTextParamsMetaNames attributes
+        mock_gen_text_params_class.MAX_NEW_TOKENS = 'max_new_tokens'
+        mock_gen_text_params_class.TEMPERATURE = 'temperature'
+        mock_gen_text_params_class.TOP_P = 'top_p'
+        mock_gen_text_params_class.TOP_K = 'top_k'
+
+        llm = WatsonX(model='ibm/granite-13b-chat-v2')
+
+        # Check that ModelInference was called with custom model
+        mock_model_inference_class.assert_called_once_with(
+            model_id='ibm/granite-13b-chat-v2',
+            credentials=mock_credentials_instance,
+            project_id='test-project-id'
+        )
+
+        self.assertEqual(llm.model, 'ibm/granite-13b-chat-v2')
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_init_with_custom_params(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test initialization with custom generation parameters."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        mock_credentials_instance = MagicMock()
+        mock_model_inference_instance = MagicMock()
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_model_inference_class.return_value = mock_model_inference_instance
+
+        # Mock the GenTextParamsMetaNames attributes
+        mock_gen_text_params_class.MAX_NEW_TOKENS = 'max_new_tokens'
+        mock_gen_text_params_class.TEMPERATURE = 'temperature'
+        mock_gen_text_params_class.TOP_P = 'top_p'
+        mock_gen_text_params_class.TOP_K = 'top_k'
+
+        llm = WatsonX(
+            max_new_tokens=500,
+            temperature=0.7,
+            top_p=0.9,
+            top_k=40
+        )
+
+        # Check that generation parameters were set correctly
+        expected_params = {
+            'max_new_tokens': 500,
+            'temperature': 0.7,
+            'top_p': 0.9,
+            'top_k': 40
+        }
+        self.assertEqual(llm.generation_params, expected_params)
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    def test_init_missing_api_key(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test initialization with missing API key."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError) as context:
+                WatsonX()
+
+            self.assertIn("WATSONX_APIKEY", str(context.exception))
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key'
+    })
+    def test_init_missing_url(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test initialization with missing URL."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        with self.assertRaises(ValueError) as context:
+            WatsonX()
+
+        self.assertIn("WATSONX_URL", str(context.exception))
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com'
+    })
+    def test_init_missing_project_and_space_id(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test initialization with missing both project_id and space_id."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        with self.assertRaises(ValueError) as context:
+            WatsonX()
+
+        self.assertIn("WATSONX_PROJECT_ID", str(context.exception))
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_chat_simple_message(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test chat with a simple message."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        mock_credentials_instance = MagicMock()
+        mock_model_inference_instance = MagicMock()
+        mock_model_inference_instance.generate_text.return_value = "This is a test response from WatsonX."
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_model_inference_class.return_value = mock_model_inference_instance
+
+        # Mock the GenTextParamsMetaNames attributes
+        mock_gen_text_params_class.MAX_NEW_TOKENS = 'max_new_tokens'
+        mock_gen_text_params_class.TEMPERATURE = 'temperature'
+        mock_gen_text_params_class.TOP_P = 'top_p'
+        mock_gen_text_params_class.TOP_K = 'top_k'
+
+        llm = WatsonX()
+
+        messages = [
+            {"role": "user", "content": "Hello, how are you?"}
+        ]
+
+        response = llm.chat(messages)
+
+        # Check that generate_text was called
+        mock_model_inference_instance.generate_text.assert_called_once()
+        call_args = mock_model_inference_instance.generate_text.call_args
+
+        # Check the prompt format
+        expected_prompt = "Human: Hello, how are you?\n\nAssistant:"
+        self.assertEqual(call_args[1]['prompt'], expected_prompt)
+
+        # Check response
+        self.assertEqual(response.content, "This is a test response from WatsonX.")
+        self.assertIsInstance(response.total_tokens, int)
+        self.assertGreater(response.total_tokens, 0)
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_chat_with_system_message(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test chat with system and user messages."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        mock_credentials_instance = MagicMock()
+        mock_model_inference_instance = MagicMock()
+        mock_model_inference_instance.generate_text.return_value = "4"
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_model_inference_class.return_value = mock_model_inference_instance
+
+        # Mock the GenTextParamsMetaNames attributes
+        mock_gen_text_params_class.MAX_NEW_TOKENS = 'max_new_tokens'
+        mock_gen_text_params_class.TEMPERATURE = 'temperature'
+        mock_gen_text_params_class.TOP_P = 'top_p'
+        mock_gen_text_params_class.TOP_K = 'top_k'
+
+        llm = WatsonX()
+
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is 2+2?"}
+        ]
+
+        response = llm.chat(messages)
+
+        # Check that generate_text was called
+        mock_model_inference_instance.generate_text.assert_called_once()
+        call_args = mock_model_inference_instance.generate_text.call_args
+
+        # Check the prompt format
+        expected_prompt = "System: You are a helpful assistant.\n\nHuman: What is 2+2?\n\nAssistant:"
+        self.assertEqual(call_args[1]['prompt'], expected_prompt)
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_chat_conversation_history(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test chat with conversation history."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        mock_credentials_instance = MagicMock()
+        mock_model_inference_instance = MagicMock()
+        mock_model_inference_instance.generate_text.return_value = "6"
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_model_inference_class.return_value = mock_model_inference_instance
+
+        # Mock the GenTextParamsMetaNames attributes
+        mock_gen_text_params_class.MAX_NEW_TOKENS = 'max_new_tokens'
+        mock_gen_text_params_class.TEMPERATURE = 'temperature'
+        mock_gen_text_params_class.TOP_P = 'top_p'
+        mock_gen_text_params_class.TOP_K = 'top_k'
+
+        llm = WatsonX()
+
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "2+2 equals 4."},
+            {"role": "user", "content": "What about 3+3?"}
+        ]
+
+        response = llm.chat(messages)
+
+        # Check that generate_text was called
+        mock_model_inference_instance.generate_text.assert_called_once()
+        call_args = mock_model_inference_instance.generate_text.call_args
+
+        # Check the prompt format includes conversation history
+        expected_prompt = ("System: You are a helpful assistant.\n\n"
+                          "Human: What is 2+2?\n\n"
+                          "Assistant: 2+2 equals 4.\n\n"
+                          "Human: What about 3+3?\n\n"
+                          "Assistant:")
+        self.assertEqual(call_args[1]['prompt'], expected_prompt)
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_chat_error_handling(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test error handling in chat method."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        mock_credentials_instance = MagicMock()
+        mock_model_inference_instance = MagicMock()
+        mock_model_inference_instance.generate_text.side_effect = Exception("API Error")
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_model_inference_class.return_value = mock_model_inference_instance
+
+        # Mock the GenTextParamsMetaNames attributes
+        mock_gen_text_params_class.MAX_NEW_TOKENS = 'max_new_tokens'
+        mock_gen_text_params_class.TEMPERATURE = 'temperature'
+        mock_gen_text_params_class.TOP_P = 'top_p'
+        mock_gen_text_params_class.TOP_K = 'top_k'
+
+        llm = WatsonX()
+
+        messages = [{"role": "user", "content": "Hello"}]
+
+        # Test that the exception is properly wrapped
+        with self.assertRaises(RuntimeError) as context:
+            llm.chat(messages)
+
+        self.assertIn("Error generating response with WatsonX", str(context.exception))
+
+    @patch('deepsearcher.llm.watsonx.ModelInference')
+    @patch('deepsearcher.llm.watsonx.Credentials')
+    @patch('deepsearcher.llm.watsonx.GenTextParamsMetaNames')
+    @patch.dict('os.environ', {
+        'WATSONX_APIKEY': 'test-api-key',
+        'WATSONX_URL': 'https://test.watsonx.com',
+        'WATSONX_PROJECT_ID': 'test-project-id'
+    })
+    def test_messages_to_prompt(self, mock_gen_text_params_class, mock_credentials_class, mock_model_inference_class):
+        """Test the _messages_to_prompt method."""
+        from deepsearcher.llm.watsonx import WatsonX
+
+        mock_credentials_instance = MagicMock()
+        mock_model_inference_instance = MagicMock()
+
+        mock_credentials_class.return_value = mock_credentials_instance
+        mock_model_inference_class.return_value = mock_model_inference_instance
+
+        # Mock the GenTextParamsMetaNames attributes
+        mock_gen_text_params_class.MAX_NEW_TOKENS = 'max_new_tokens'
+        mock_gen_text_params_class.TEMPERATURE = 'temperature'
+        mock_gen_text_params_class.TOP_P = 'top_p'
+        mock_gen_text_params_class.TOP_K = 'top_k'
+
+        llm = WatsonX()
+
+        messages = [
+            {"role": "system", "content": "System message"},
+            {"role": "user", "content": "User message"},
+            {"role": "assistant", "content": "Assistant message"},
+            {"role": "user", "content": "Another user message"}
+        ]
+
+        prompt = llm._messages_to_prompt(messages)
+
+        expected_prompt = ("System: System message\n\n"
+                          "Human: User message\n\n"
+                          "Assistant: Assistant message\n\n"
+                          "Human: Another user message\n\n"
+                          "Assistant:")
+
+        self.assertEqual(prompt, expected_prompt)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description

This PR introduces support for IBM watsonx.ai as part of the deep-searcher's providers. Fixes #241 

## 📁 Files Added/Modified

### New Files Created:
1. `deepsearcher/embedding/watsonx_embedding.py` - WatsonX embedding implementation
2. `deepsearcher/llm/watsonx.py` - WatsonX LLM implementation
3. `tests/embedding/test_watsonx_embedding.py` - Unit tests for WatsonX embedding
4. `tests/llm/test_watsonx.py` - Unit tests for WatsonX LLM
5. `examples/basic_watsonx_example.py` - Usage examples for WatsonX integration

### Modified Files:
1. `deepsearcher/embedding/__init__.py` - Added WatsonXEmbedding import
2. `deepsearcher/llm/__init__.py` - Added WatsonX import
3. `README.md` - Added references to IBM watsonx.ai options
4. `docs/configuration/embedding.md` - Added references to IBM watsonx.ai options
5. `docs/configuration/llm.md` - Added references to IBM watsonx.ai options
6. `docs/integrations/index.md` - Added references to IBM watsonx.ai options
7. `pyproject.toml` - Added dependencies


## 🔧 Configuration

### Environment Variables Required:
```bash
export WATSONX_APIKEY="your-watsonx-api-key"
export WATSONX_URL="https://your-watsonx-instance.com"
export WATSONX_PROJECT_ID="your-project-id"
```

### Installation:

Required to make it work
```bash
pip install ibm-watsonx-ai
```

## 🚀 Usage Examples

### WatsonXEmbedding Configuration:
```python
from deepsearcher.configuration import Configuration

config = Configuration()

# Basic configuration
config.set_provider_config("embedding", "WatsonXEmbedding", {})

# With custom model
config.set_provider_config("embedding", "WatsonXEmbedding", {
    "model": "ibm/slate-125m-english-rtrvr"
})
```

### WatsonX LLM Configuration:
```python
# Basic configuration
config.set_provider_config("llm", "WatsonX", {})

# With custom model and parameters
config.set_provider_config("llm", "WatsonX", {
    "model": "ibm/granite-3-3-8b-instruct",
    "max_new_tokens": 1000,
    "temperature": 0.7,
    "top_p": 0.9,
    "top_k": 50
})
```

## 🔍 Supported Models

### Embedding Models:
- `ibm/slate-125m-english-rtrvr-v2` (768 dimensions) - Default
- Other embedding models available on WatsonX platform

### LLM Models:
- `ibm/granite-3-3-8b-instruct` - Default
- Other foundation models available on WatsonX platform

## 🧪 Testing

### Run WatsonX Embedding Tests:
```bash
uv run python -m pytest tests/embedding/test_watsonx_embedding.py -v
```

### Run WatsonX LLM Tests:
```bash
uv run python -m pytest tests/llm/test_watsonx.py -v
```

### Run Example:
```bash
python examples/basic_watsonx_example.py
```

## 🔒 Authentication Options

### Option 1: Environment Variables (Recommended)
```bash
export WATSONX_APIKEY="your-api-key"
export WATSONX_URL="https://your-instance.com"
export WATSONX_PROJECT_ID="your-project-id"
```

### Option 2: Direct Configuration
```python
config.set_provider_config("embedding", "WatsonXEmbedding", {
    "api_key": "your-api-key",
    "url": "https://your-instance.com",
    "project_id": "your-project-id",
    "model": "ibm/slate-125m-english-rtrvr"
})
```

