### PR TITLE
docs: Correct malformed URL references for uv installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pip install "deepsearcher[ollama]"
 ```
 
 #### Option 2: Install in Development Mode
-We recommend using [uv](https://github.com/astral-sh/uv) for faster and more reliable installation. Follow the [offical installation instructions](https://docs.astral.sh/uvgetting-started/installation/) to install it.
+We recommend using [uv](https://github.com/astral-sh/uv) for faster and more reliable installation. Follow the [offical installation instructions](https://docs.astral.sh/uv/getting-started/installation/) to install it.
 
 Clone the repository and navigate to the project directory:
 ```shell

--- a/docs/installation/development.md
+++ b/docs/installation/development.md
@@ -29,7 +29,7 @@ This guide is for contributors who want to modify DeepSearcher's code or develop
     irm https://astral.sh/uv/install.ps1 | iex
     ```
 
-For more options, see the [official uv installation guide](https://docs.astral.sh/uvgetting-started/installation/).
+For more options, see the [official uv installation guide](https://docs.astral.sh/uv/getting-started/installation/).
 
 ### Step 2: Clone the repository
 


### PR DESCRIPTION
#### Description

This pull request resolves a minor typo in the documentation where the hyperlink to the official `uv` installation guide was malformed, leading to a 404 error.

#### Issue

* **Malformed URL:** `https://docs.astral.sh/uvgetting-started/installation/`
* **Corrected URL:** `https://docs.astral.sh/uv/getting-started/installation/`

The broken link was present in the following files:
* `README.md`
* `docs/installation/development.md`

#### Changes Made

The malformed URL has been corrected in both locations to point to the proper address. No other changes are included in this pull request.

This contribution adheres to the guidelines outlined in `CONTRIBUTING.md`, and the commit has been signed-off to certify the Developer Certificate of Origin.