### PR TITLE
feat: add MiniMax as LLM and embedding provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ result = query("Write a report about xxx.") # Your question here
 #### LLM Configuration
 
 <pre><code>config.set_provider_config("llm", "(LLMName)", "(Arguments dict)")</code></pre>
-<p>The "LLMName" can be one of the following: ["DeepSeek", "OpenAI", "XAI", "SiliconFlow", "Aliyun", "PPIO", "TogetherAI", "Gemini", "Ollama", "Novita", "Jiekou.AI"]</p>
+<p>The "LLMName" can be one of the following: ["DeepSeek", "OpenAI", "XAI", "SiliconFlow", "Aliyun", "PPIO", "TogetherAI", "Gemini", "Ollama", "Novita", "Jiekou.AI", "MiniMax"]</p>
 <p> The "Arguments dict" is a dictionary that contains the necessary arguments for the LLM class.</p>
 
 <details>
@@ -181,6 +181,13 @@ result = query("Write a report about xxx.") # Your question here
 </details>
 
 <details>
+  <summary>Example (MiniMax)</summary>
+    <p> Make sure you have prepared your MiniMax API KEY as an env variable <code>MINIMAX_API_KEY</code>. You can create an API Key at <a href="https://platform.minimaxi.com">MiniMax Platform</a>.</p>
+    <pre><code>config.set_provider_config("llm", "MiniMax", {"model": "MiniMax-M2.7"})</code></pre>
+    <p> More details about MiniMax: https://platform.minimaxi.com/document/introduction </p>
+</details>
+
+<details>
   <summary>Example (Ollama)</summary>
   <p> Follow <a href="https://github.com/jmorganca/ollama">these instructions</a> to set up and run a local Ollama instance:</p>
   <p> <a href="https://ollama.ai/download">Download</a> and install Ollama onto the available supported platforms (including Windows Subsystem for Linux).</p>
@@ -223,7 +230,7 @@ result = query("Write a report about xxx.") # Your question here
 
 #### Embedding Model Configuration
 <pre><code>config.set_provider_config("embedding", "(EmbeddingModelName)", "(Arguments dict)")</code></pre>
-<p>The "EmbeddingModelName" can be one of the following: ["MilvusEmbedding", "OpenAIEmbedding", "VoyageEmbedding", "SiliconflowEmbedding", "PPIOEmbedding", "NovitaEmbedding", "JiekouAIEmbedding"]</p>
+<p>The "EmbeddingModelName" can be one of the following: ["MilvusEmbedding", "OpenAIEmbedding", "VoyageEmbedding", "SiliconflowEmbedding", "PPIOEmbedding", "NovitaEmbedding", "JiekouAIEmbedding", "MiniMaxEmbedding"]</p>
 <p> The "Arguments dict" is a dictionary that contains the necessary arguments for the embedding model class.</p>
 
 <details>
@@ -320,6 +327,13 @@ result = query("Write a report about xxx.") # Your question here
     <p> Make sure you have prepared your Jiekou.AI API KEY as an env variable <code>JIEKOU_API_KEY</code>.</p>
     <pre><code>config.set_provider_config("embedding", "JiekouAIEmbedding", {"model": "qwen/qwen3-embedding-8b"})</code></pre>
     <p> More details about Jiekou.AI: https://docs.jiekou.ai/docs/support/quickstart?utm_source=github_deep-searcher </p>
+</details>
+
+<details>
+  <summary>Example (MiniMax embedding)</summary>
+    <p> Make sure you have prepared your MiniMax API KEY as an env variable <code>MINIMAX_API_KEY</code>. You can create an API Key at <a href="https://platform.minimaxi.com">MiniMax Platform</a>.</p>
+    <pre><code>config.set_provider_config("embedding", "MiniMaxEmbedding", {"model": "embo-01"})</code></pre>
+    <p> More details about MiniMax: https://platform.minimaxi.com/document/text-embedding </p>
 </details>
 
 <details>
@@ -562,6 +576,7 @@ nest_asyncio.apply()
 - [Novita AI](https://novita.ai/docs/api-reference/model-apis-llm-create-embeddings?utm_source=github_deep-searcher&utm_medium=github_readme&utm_campaign=link) (`NOVITA_API_KEY` env variable required)
 - [IBM watsonx.ai](https://www.ibm.com/products/watsonx-ai/foundation-models#ibmembedding) (`WATSONX_APIKEY`, `WATSONX_URL`, `WATSONX_PROJECT_ID` env variables required)
 - [Jiekou.AI](https://jiekou.ai/?utm_source=github_deep-searcher) (`JIEKOU_API_KEY` env variable required)
+- [MiniMax](https://platform.minimaxi.com/document/text-embedding) (`MINIMAX_API_KEY` env variable required)
 
 ### 🔹 LLM Support
 - [OpenAI](https://platform.openai.com/docs/models) (`OPENAI_API_KEY` env variable required)
@@ -577,6 +592,7 @@ nest_asyncio.apply()
 - [Novita AI](https://novita.ai/docs/guides/introduction?utm_source=github_deep-searcher&utm_medium=github_readme&utm_campaign=link) (`NOVITA_API_KEY` env variable required)
 - [IBM watsonx.ai](https://www.ibm.com/products/watsonx-ai/foundation-models#ibmfm) (`WATSONX_APIKEY`, `WATSONX_URL`, `WATSONX_PROJECT_ID` env variable required)
 - [Jiekou.AI](https://jiekou.ai/?utm_source=github_deep-searcher) (`JIEKOU_API_KEY` env variable required)
+- [MiniMax](https://platform.minimaxi.com/document/introduction) (`MINIMAX_API_KEY` env variable required)
 
 ### 🔹 Document Loader
 - Local File

--- a/deepsearcher/config.yaml
+++ b/deepsearcher/config.yaml
@@ -52,6 +52,12 @@ provide_settings:
 #      model: "deepseek/deepseek-v3-0324"
 ##      api_key: "sk_xxxxxx"  # Uncomment to override the `NOVITA_API_KEY` set in the environment variable
 
+#    provider: "MiniMax"
+#    config:
+#      model: "MiniMax-M2.7"
+##      api_key: "xxxx"  # Uncomment to override the `MINIMAX_API_KEY` set in the environment variable
+##      base_url: ""
+
   embedding:
     provider: "OpenAIEmbedding"
     config:
@@ -104,6 +110,11 @@ provide_settings:
     # provider: "SentenceTransformerEmbedding"
     # config:
     #   model: "BAAI/bge-large-zh-v1.5"
+
+#    provider: "MiniMaxEmbedding"
+#    config:
+#      model: "embo-01"
+##      api_key: "xxxx"  # Uncomment to override the `MINIMAX_API_KEY` set in the environment variable
 
   file_loader:
     provider: "PDFLoader"

--- a/deepsearcher/embedding/__init__.py
+++ b/deepsearcher/embedding/__init__.py
@@ -3,6 +3,7 @@ from .fastembed_embdding import FastEmbedEmbedding
 from .gemini_embedding import GeminiEmbedding
 from .glm_embedding import GLMEmbedding
 from .jiekouai_embedding import JiekouAIEmbedding
+from .minimax_embedding import MiniMaxEmbedding
 from .milvus_embedding import MilvusEmbedding
 from .novita_embedding import NovitaEmbedding
 from .ollama_embedding import OllamaEmbedding
@@ -30,4 +31,5 @@ __all__ = [
     "SentenceTransformerEmbedding",
     "WatsonXEmbedding",
     "JiekouAIEmbedding",
+    "MiniMaxEmbedding",
 ]

--- a/deepsearcher/embedding/minimax_embedding.py
+++ b/deepsearcher/embedding/minimax_embedding.py
@@ -1,0 +1,139 @@
+import os
+from typing import List, Union
+
+import requests
+
+from deepsearcher.embedding.base import BaseEmbedding
+
+MINIMAX_MODEL_DIM_MAP = {
+    "embo-01": 1536,
+}
+
+MINIMAX_EMBEDDING_API = "https://api.minimax.io/v1/embeddings"
+
+
+class MiniMaxEmbedding(BaseEmbedding):
+    """
+    MiniMax embedding model implementation.
+
+    This class provides an interface to the MiniMax embedding API, which offers
+    text embedding capabilities via the embo-01 model.
+
+    API Documentation: https://platform.minimaxi.com/document/text-embedding
+
+    Attributes:
+        model (str): The MiniMax embedding model identifier.
+        api_key (str): The API key for authentication.
+        batch_size (int): Maximum number of texts to process in a single batch.
+    """
+
+    def __init__(self, model="embo-01", batch_size=32, **kwargs):
+        """
+        Initialize the MiniMax embedding model.
+
+        Args:
+            model (str): The model identifier to use for embeddings. Default is "embo-01".
+            batch_size (int): Maximum number of texts to process in a single batch. Default is 32.
+            **kwargs: Additional keyword arguments.
+                - api_key (str, optional): The MiniMax API key. If not provided,
+                  it will be read from the MINIMAX_API_KEY environment variable.
+
+        Raises:
+            RuntimeError: If no API key is provided or found in environment variables.
+        """
+        self.model = model
+        if "api_key" in kwargs:
+            api_key = kwargs.pop("api_key")
+        else:
+            api_key = os.getenv("MINIMAX_API_KEY")
+
+        if not api_key or len(api_key) == 0:
+            raise RuntimeError("api_key is required for MiniMaxEmbedding")
+        self.api_key = api_key
+        self.batch_size = batch_size
+
+    def embed_query(self, text: str) -> List[float]:
+        """
+        Embed a single query text.
+
+        Args:
+            text (str): The query text to embed.
+
+        Returns:
+            List[float]: A list of floats representing the embedding vector.
+
+        Note:
+            Uses type="query" for retrieval query embeddings.
+        """
+        return self._embed_input([text], embed_type="query")[0]
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """
+        Embed a list of document texts.
+
+        This method handles batching of document embeddings based on the configured
+        batch size to optimize API calls.
+
+        Args:
+            texts (List[str]): A list of document texts to embed.
+
+        Returns:
+            List[List[float]]: A list of embedding vectors, one for each input text.
+        """
+        if self.batch_size > 0:
+            if len(texts) > self.batch_size:
+                batch_texts = [
+                    texts[i : i + self.batch_size] for i in range(0, len(texts), self.batch_size)
+                ]
+                embeddings = []
+                for batch_text in batch_texts:
+                    batch_embeddings = self._embed_input(batch_text, embed_type="db")
+                    embeddings.extend(batch_embeddings)
+                return embeddings
+            return self._embed_input(texts, embed_type="db")
+        return [self.embed_query(text) for text in texts]
+
+    def _embed_input(self, texts: List[str], embed_type: str = "db") -> List[List[float]]:
+        """
+        Internal method to handle the API call for embedding inputs.
+
+        The MiniMax embedding API uses a custom format with 'texts' and 'type' fields,
+        and returns vectors in a 'vectors' field.
+
+        Args:
+            texts (List[str]): A list of text strings to embed.
+            embed_type (str): The embedding type - "db" for document storage,
+                            "query" for search queries.
+
+        Returns:
+            List[List[float]]: A list of embedding vectors for the inputs.
+
+        Raises:
+            HTTPError: If the API request fails.
+        """
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {"model": self.model, "texts": texts, "type": embed_type}
+        response = requests.request(
+            "POST", MINIMAX_EMBEDDING_API, json=payload, headers=headers
+        )
+        response.raise_for_status()
+        result = response.json()
+        base_resp = result.get("base_resp", {})
+        if base_resp.get("status_code", 0) != 0:
+            raise RuntimeError(
+                f"MiniMax embedding API error: {base_resp.get('status_msg', 'unknown error')}"
+            )
+        return result["vectors"]
+
+    @property
+    def dimension(self) -> int:
+        """
+        Get the dimensionality of the embeddings for the current model.
+
+        Returns:
+            int: The number of dimensions in the embedding vectors.
+        """
+        return MINIMAX_MODEL_DIM_MAP[self.model]

--- a/deepsearcher/llm/__init__.py
+++ b/deepsearcher/llm/__init__.py
@@ -6,6 +6,7 @@ from .deepseek import DeepSeek
 from .gemini import Gemini
 from .glm import GLM
 from .jiekouai import JiekouAI
+from .minimax import MiniMax
 from .novita import Novita
 from .ollama import Ollama
 from .openai_llm import OpenAI
@@ -34,4 +35,5 @@ __all__ = [
     "Aliyun",
     "WatsonX",
     "JiekouAI",
+    "MiniMax",
 ]

--- a/deepsearcher/llm/minimax.py
+++ b/deepsearcher/llm/minimax.py
@@ -1,0 +1,65 @@
+import os
+from typing import Dict, List
+
+from deepsearcher.llm.base import BaseLLM, ChatResponse
+
+
+class MiniMax(BaseLLM):
+    """
+    MiniMax language model implementation.
+
+    This class provides an interface to interact with MiniMax's language models
+    through their OpenAI-compatible API. MiniMax offers powerful reasoning and
+    generation capabilities with models like MiniMax-M2.7.
+
+    API Documentation: https://platform.minimaxi.com/document/introduction
+
+    Attributes:
+        model (str): The MiniMax model identifier to use.
+        client: The OpenAI-compatible client instance for MiniMax API.
+    """
+
+    def __init__(self, model: str = "MiniMax-M2.7", **kwargs):
+        """
+        Initialize a MiniMax language model client.
+
+        Args:
+            model (str, optional): The model identifier to use. Defaults to "MiniMax-M2.7".
+            **kwargs: Additional keyword arguments to pass to the OpenAI client.
+                - api_key: MiniMax API key. If not provided, uses MINIMAX_API_KEY environment variable.
+                - base_url: MiniMax API base URL. If not provided, uses MINIMAX_BASE_URL environment
+                  variable or defaults to "https://api.minimax.io/v1".
+        """
+        from openai import OpenAI as OpenAI_
+
+        self.model = model
+        if "api_key" in kwargs:
+            api_key = kwargs.pop("api_key")
+        else:
+            api_key = os.getenv("MINIMAX_API_KEY")
+        if "base_url" in kwargs:
+            base_url = kwargs.pop("base_url")
+        else:
+            base_url = os.getenv("MINIMAX_BASE_URL", default="https://api.minimax.io/v1")
+        self.client = OpenAI_(api_key=api_key, base_url=base_url, **kwargs)
+
+    def chat(self, messages: List[Dict]) -> ChatResponse:
+        """
+        Send a chat message to the MiniMax model and get a response.
+
+        Args:
+            messages (List[Dict]): A list of message dictionaries, typically in the format
+                                  [{"role": "system", "content": "..."},
+                                   {"role": "user", "content": "..."}]
+
+        Returns:
+            ChatResponse: An object containing the model's response and token usage information.
+        """
+        completion = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+        )
+        return ChatResponse(
+            content=completion.choices[0].message.content,
+            total_tokens=completion.usage.total_tokens,
+        )

--- a/tests/embedding/test_minimax_embedding.py
+++ b/tests/embedding/test_minimax_embedding.py
@@ -1,0 +1,173 @@
+import unittest
+import os
+from unittest.mock import patch, MagicMock
+
+import requests
+from deepsearcher.embedding import MiniMaxEmbedding
+
+
+class TestMiniMaxEmbedding(unittest.TestCase):
+    """Tests for the MiniMaxEmbedding class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create patches for requests
+        self.requests_patcher = patch('requests.request')
+        self.mock_request = self.requests_patcher.start()
+
+        # Set up mock response
+        self.mock_response = MagicMock()
+        self.mock_response.json.return_value = {
+            'vectors': [
+                [0.1] * 1536  # embo-01 has 1536 dimensions
+            ]
+        }
+        self.mock_response.raise_for_status = MagicMock()
+        self.mock_request.return_value = self.mock_response
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.requests_patcher.stop()
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'fake-api-key'}, clear=True)
+    def test_init_default(self):
+        """Test initialization with default parameters."""
+        embedding = MiniMaxEmbedding()
+
+        self.assertEqual(embedding.model, 'embo-01')
+        self.assertEqual(embedding.api_key, 'fake-api-key')
+        self.assertEqual(embedding.batch_size, 32)
+
+    @patch.dict('os.environ', {}, clear=True)
+    def test_init_with_api_key(self):
+        """Test initialization with API key parameter."""
+        embedding = MiniMaxEmbedding(api_key='test-api-key')
+
+        self.assertEqual(embedding.api_key, 'test-api-key')
+
+    @patch.dict('os.environ', {}, clear=True)
+    def test_init_without_api_key(self):
+        """Test initialization without API key raises error."""
+        with self.assertRaises(RuntimeError):
+            MiniMaxEmbedding()
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'fake-api-key'}, clear=True)
+    def test_embed_query(self):
+        """Test embedding a single query."""
+        embedding = MiniMaxEmbedding()
+
+        query = "This is a test query"
+        result = embedding.embed_query(query)
+
+        # Verify that request was called with type="query"
+        self.mock_request.assert_called_once_with(
+            'POST',
+            'https://api.minimax.io/v1/embeddings',
+            json={
+                'model': 'embo-01',
+                'texts': [query],
+                'type': 'query'
+            },
+            headers={
+                'Authorization': 'Bearer fake-api-key',
+                'Content-Type': 'application/json'
+            }
+        )
+
+        self.assertEqual(result, [0.1] * 1536)
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'fake-api-key'}, clear=True)
+    def test_embed_documents(self):
+        """Test embedding multiple documents."""
+        embedding = MiniMaxEmbedding()
+
+        texts = ["text 1", "text 2", "text 3"]
+
+        # Set up mock response for multiple documents
+        self.mock_response.json.return_value = {
+            'vectors': [
+                [0.1 * (i + 1)] * 1536
+                for i in range(3)
+            ]
+        }
+
+        results = embedding.embed_documents(texts)
+
+        # Verify that request was called with type="db"
+        self.mock_request.assert_called_once_with(
+            'POST',
+            'https://api.minimax.io/v1/embeddings',
+            json={
+                'model': 'embo-01',
+                'texts': texts,
+                'type': 'db'
+            },
+            headers={
+                'Authorization': 'Bearer fake-api-key',
+                'Content-Type': 'application/json'
+            }
+        )
+
+        self.assertEqual(len(results), 3)
+        for i, result in enumerate(results):
+            self.assertEqual(result, [0.1 * (i + 1)] * 1536)
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'fake-api-key'}, clear=True)
+    def test_embed_documents_with_batching(self):
+        """Test embedding documents with batching."""
+        embedding = MiniMaxEmbedding()
+
+        texts = ["text " + str(i) for i in range(50)]  # More than batch_size
+
+        def mock_batch_response(*args, **kwargs):
+            batch_input = kwargs['json']['texts']
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = {
+                'vectors': [
+                    [0.1] * 1536
+                    for _ in range(len(batch_input))
+                ]
+            }
+            mock_resp.raise_for_status = MagicMock()
+            return mock_resp
+
+        self.mock_request.side_effect = mock_batch_response
+
+        results = embedding.embed_documents(texts)
+
+        # Check that request was called multiple times
+        self.assertTrue(self.mock_request.call_count > 1)
+
+        # Check the results
+        self.assertEqual(len(results), 50)
+        for result in results:
+            self.assertEqual(result, [0.1] * 1536)
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'fake-api-key'}, clear=True)
+    def test_dimension_property(self):
+        """Test the dimension property."""
+        embedding = MiniMaxEmbedding()
+
+        self.assertEqual(embedding.dimension, 1536)
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'fake-api-key'}, clear=True)
+    def test_embed_query_uses_query_type(self):
+        """Test that embed_query uses type='query' for retrieval."""
+        embedding = MiniMaxEmbedding()
+        embedding.embed_query("search query")
+
+        call_args = self.mock_request.call_args
+        self.assertEqual(call_args[1]['json']['type'], 'query')
+
+    @patch.dict('os.environ', {'MINIMAX_API_KEY': 'fake-api-key'}, clear=True)
+    def test_embed_documents_uses_db_type(self):
+        """Test that embed_documents uses type='db' for storage."""
+        embedding = MiniMaxEmbedding()
+        embedding.embed_documents(["doc text"])
+
+        call_args = self.mock_request.call_args
+        self.assertEqual(call_args[1]['json']['type'], 'db')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/embedding/test_minimax_embedding_integration.py
+++ b/tests/embedding/test_minimax_embedding_integration.py
@@ -1,0 +1,55 @@
+"""
+Integration tests for MiniMax Embedding provider.
+
+These tests require a valid MINIMAX_API_KEY environment variable.
+Run with: MINIMAX_API_KEY=your_key python -m pytest tests/embedding/test_minimax_embedding_integration.py -v
+"""
+
+import os
+import unittest
+
+import pytest
+
+
+@pytest.mark.skipif(
+    not os.getenv("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY environment variable not set",
+)
+class TestMiniMaxEmbeddingIntegration(unittest.TestCase):
+    """Integration tests for the MiniMax embedding provider."""
+
+    def test_embed_query(self):
+        """Test embedding a single query."""
+        from deepsearcher.embedding import MiniMaxEmbedding
+
+        embedding = MiniMaxEmbedding()
+        result = embedding.embed_query("Hello world")
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1536)
+        self.assertIsInstance(result[0], float)
+
+    def test_embed_documents(self):
+        """Test embedding multiple documents."""
+        from deepsearcher.embedding import MiniMaxEmbedding
+
+        embedding = MiniMaxEmbedding()
+        texts = ["First document", "Second document"]
+        results = embedding.embed_documents(texts)
+
+        self.assertEqual(len(results), 2)
+        for result in results:
+            self.assertEqual(len(result), 1536)
+
+    def test_dimension_property(self):
+        """Test the dimension property matches actual embeddings."""
+        from deepsearcher.embedding import MiniMaxEmbedding
+
+        embedding = MiniMaxEmbedding()
+        result = embedding.embed_query("Test")
+
+        self.assertEqual(len(result), embedding.dimension)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/llm/test_minimax.py
+++ b/tests/llm/test_minimax.py
@@ -1,0 +1,156 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import logging
+
+# Disable logging for tests
+logging.disable(logging.CRITICAL)
+
+from deepsearcher.llm import MiniMax
+from deepsearcher.llm.base import ChatResponse
+
+
+class TestMiniMax(unittest.TestCase):
+    """Tests for the MiniMax LLM provider."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create mock module and components
+        self.mock_openai = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_chat = MagicMock()
+        self.mock_completions = MagicMock()
+
+        # Set up the mock module structure
+        self.mock_openai.OpenAI = MagicMock(return_value=self.mock_client)
+        self.mock_client.chat = self.mock_chat
+        self.mock_chat.completions = self.mock_completions
+
+        # Set up mock response
+        self.mock_response = MagicMock()
+        self.mock_choice = MagicMock()
+        self.mock_message = MagicMock()
+        self.mock_usage = MagicMock()
+
+        self.mock_message.content = "Test response"
+        self.mock_choice.message = self.mock_message
+        self.mock_usage.total_tokens = 100
+
+        self.mock_response.choices = [self.mock_choice]
+        self.mock_response.usage = self.mock_usage
+        self.mock_completions.create.return_value = self.mock_response
+
+        # Create the module patcher
+        self.module_patcher = patch.dict('sys.modules', {'openai': self.mock_openai})
+        self.module_patcher.start()
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.module_patcher.stop()
+
+    def test_init_default(self):
+        """Test initialization with default parameters."""
+        with patch.dict('os.environ', {}, clear=True):
+            llm = MiniMax()
+            self.mock_openai.OpenAI.assert_called_once_with(
+                api_key=None,
+                base_url="https://api.minimax.io/v1"
+            )
+            self.assertEqual(llm.model, "MiniMax-M2.7")
+
+    def test_init_with_api_key_from_env(self):
+        """Test initialization with API key from environment variable."""
+        api_key = "test_api_key_from_env"
+        base_url = "https://custom.minimax.api"
+        with patch.dict(os.environ, {
+            "MINIMAX_API_KEY": api_key,
+            "MINIMAX_BASE_URL": base_url
+        }):
+            llm = MiniMax()
+            self.mock_openai.OpenAI.assert_called_with(
+                api_key=api_key,
+                base_url=base_url
+            )
+
+    def test_init_with_api_key_parameter(self):
+        """Test initialization with API key as parameter."""
+        api_key = "test_api_key_param"
+        with patch.dict('os.environ', {}, clear=True):
+            llm = MiniMax(api_key=api_key)
+            self.mock_openai.OpenAI.assert_called_with(
+                api_key=api_key,
+                base_url="https://api.minimax.io/v1"
+            )
+
+    def test_init_with_custom_model(self):
+        """Test initialization with custom model."""
+        with patch.dict('os.environ', {}, clear=True):
+            model = "MiniMax-M2.5-highspeed"
+            llm = MiniMax(model=model)
+            self.assertEqual(llm.model, model)
+
+    def test_init_with_custom_base_url(self):
+        """Test initialization with custom base URL."""
+        with patch.dict('os.environ', {}, clear=True):
+            base_url = "https://custom.minimax.api"
+            llm = MiniMax(base_url=base_url)
+            self.mock_openai.OpenAI.assert_called_with(
+                api_key=None,
+                base_url=base_url
+            )
+
+    def test_chat_single_message(self):
+        """Test chat with a single message."""
+        with patch.dict('os.environ', {}, clear=True):
+            llm = MiniMax()
+
+        messages = [{"role": "user", "content": "Hello"}]
+        response = llm.chat(messages)
+
+        self.mock_completions.create.assert_called_once()
+        call_args = self.mock_completions.create.call_args
+        self.assertEqual(call_args[1]["model"], "MiniMax-M2.7")
+        self.assertEqual(call_args[1]["messages"], messages)
+
+        self.assertIsInstance(response, ChatResponse)
+        self.assertEqual(response.content, "Test response")
+        self.assertEqual(response.total_tokens, 100)
+
+    def test_chat_multiple_messages(self):
+        """Test chat with multiple messages."""
+        with patch.dict('os.environ', {}, clear=True):
+            llm = MiniMax()
+
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"}
+        ]
+        response = llm.chat(messages)
+
+        self.mock_completions.create.assert_called_once()
+        call_args = self.mock_completions.create.call_args
+        self.assertEqual(call_args[1]["model"], "MiniMax-M2.7")
+        self.assertEqual(call_args[1]["messages"], messages)
+
+        self.assertIsInstance(response, ChatResponse)
+        self.assertEqual(response.content, "Test response")
+        self.assertEqual(response.total_tokens, 100)
+
+    def test_chat_with_error(self):
+        """Test chat when an error occurs."""
+        with patch.dict('os.environ', {}, clear=True):
+            llm = MiniMax()
+
+        self.mock_completions.create.side_effect = Exception("MiniMax API Error")
+
+        messages = [{"role": "user", "content": "Hello"}]
+        with self.assertRaises(Exception) as context:
+            llm.chat(messages)
+
+        self.assertEqual(str(context.exception), "MiniMax API Error")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/llm/test_minimax_integration.py
+++ b/tests/llm/test_minimax_integration.py
@@ -1,0 +1,60 @@
+"""
+Integration tests for MiniMax LLM provider.
+
+These tests require a valid MINIMAX_API_KEY environment variable.
+Run with: MINIMAX_API_KEY=your_key python -m pytest tests/llm/test_minimax_integration.py -v
+"""
+
+import os
+import unittest
+
+import pytest
+
+
+@pytest.mark.skipif(
+    not os.getenv("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY environment variable not set",
+)
+class TestMiniMaxIntegration(unittest.TestCase):
+    """Integration tests for the MiniMax LLM provider."""
+
+    def test_chat_basic(self):
+        """Test basic chat completion with MiniMax API."""
+        from deepsearcher.llm import MiniMax
+
+        llm = MiniMax(model="MiniMax-M2.7")
+        messages = [{"role": "user", "content": "Say hello in one word."}]
+        response = llm.chat(messages)
+
+        self.assertIsNotNone(response.content)
+        self.assertGreater(len(response.content), 0)
+        self.assertGreater(response.total_tokens, 0)
+
+    def test_chat_with_system_message(self):
+        """Test chat with system message."""
+        from deepsearcher.llm import MiniMax
+
+        llm = MiniMax(model="MiniMax-M2.7")
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant. Reply briefly."},
+            {"role": "user", "content": "What is 2+2?"},
+        ]
+        response = llm.chat(messages)
+
+        self.assertIsNotNone(response.content)
+        self.assertIn("4", response.content)
+
+    def test_chat_m25_highspeed(self):
+        """Test chat with MiniMax-M2.5-highspeed model."""
+        from deepsearcher.llm import MiniMax
+
+        llm = MiniMax(model="MiniMax-M2.5-highspeed")
+        messages = [{"role": "user", "content": "Say 'test' and nothing else."}]
+        response = llm.chat(messages)
+
+        self.assertIsNotNone(response.content)
+        self.assertGreater(len(response.content), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimaxi.com) as a first-class LLM and embedding provider for DeepSearcher.

### LLM Provider
- New `MiniMax` class in `deepsearcher/llm/minimax.py` using OpenAI-compatible API
- Default model: `MiniMax-M2.7` (also supports M2.5, M2.5-highspeed)
- Base URL: `https://api.minimax.io/v1`
- API key via `MINIMAX_API_KEY` env var or `api_key` parameter

### Embedding Provider
- New `MiniMaxEmbedding` class in `deepsearcher/embedding/minimax_embedding.py`
- Uses MiniMax's native embedding API with `embo-01` model (1536 dimensions)
- Supports distinct `db` and `query` embedding types for optimal retrieval
- Batch processing support with configurable batch size

### Changes
- `deepsearcher/llm/minimax.py` - LLM provider implementation
- `deepsearcher/embedding/minimax_embedding.py` - Embedding provider implementation
- `deepsearcher/llm/__init__.py` - Register MiniMax LLM
- `deepsearcher/embedding/__init__.py` - Register MiniMaxEmbedding
- `deepsearcher/config.yaml` - Add MiniMax configuration examples
- `README.md` - Add MiniMax to provider lists and usage examples
- `tests/llm/test_minimax.py` - 8 unit tests for LLM provider
- `tests/embedding/test_minimax_embedding.py` - 9 unit tests for embedding provider
- `tests/llm/test_minimax_integration.py` - 3 integration tests (requires API key)
- `tests/embedding/test_minimax_embedding_integration.py` - 3 integration tests (requires API key)

## Test Plan

- [x] All 17 unit tests pass (`pytest tests/llm/test_minimax.py tests/embedding/test_minimax_embedding.py`)
- [x] LLM integration tests pass with real API key
- [x] Existing test suite unaffected (156 passed, 3 pre-existing XAI failures)
- [ ] CI pipeline passes

## Usage

```python
# LLM
config.set_provider_config("llm", "MiniMax", {"model": "MiniMax-M2.7"})

# Embedding
config.set_provider_config("embedding", "MiniMaxEmbedding", {"model": "embo-01"})
```