### PR TITLE
fix: handle firecrawl SDK API change for ScrapeOptions import

### DIFF
--- a/deepsearcher/loader/web_crawler/firecrawl_crawler.py
+++ b/deepsearcher/loader/web_crawler/firecrawl_crawler.py
@@ -1,7 +1,14 @@
 import os
 from typing import List, Optional
 
-from firecrawl import FirecrawlApp, ScrapeOptions
+try:
+    from firecrawl import FirecrawlApp, ScrapeOptions
+except ImportError:
+    try:
+        from firecrawl import FirecrawlApp
+        from firecrawl.types import ScrapeOptions
+    except ImportError:
+        from firecrawl import FirecrawlApp, V1ScrapeOptions as ScrapeOptions  # type: ignore[attr-defined]
 from langchain_core.documents import Document
 
 from deepsearcher.loader.web_crawler.base import BaseCrawler


### PR DESCRIPTION
Fixes #255

## Problem

The `firecrawl-py` SDK changed where `ScrapeOptions` is exported across major versions:
- **Old API (pre-2.0)**: `from firecrawl import FirecrawlApp, ScrapeOptions`
- **Mid API**: `from firecrawl.types import ScrapeOptions`
- **New API**: `V1ScrapeOptions` at the top-level package

This causes an `ImportError: cannot import name 'ScrapeOptions' from 'firecrawl'` at startup, preventing the entire package from importing even when FireCrawl is not configured as the active web crawler.

## Solution

Wrap the import with a `try/except` chain that tries each import path in order, so the module works across all firecrawl-py SDK versions.

## Testing

Verified that the module imports successfully with both old and new firecrawl-py package versions by simulating the import fallback paths.