### PR TITLE
fix: remove duplicate FINAL ANSWER output in CLI query

### DIFF
--- a/deepsearcher/cli.py
+++ b/deepsearcher/cli.py
@@ -89,8 +89,6 @@ def main():
     args = parser.parse_args()
     if args.subcommand == "query":
         final_answer, refs, consumed_tokens = query(args.query, max_iter=args.max_iter)
-        log.color_print("\n==== FINAL ANSWER====\n")
-        log.color_print(final_answer)
         log.color_print("\n### References\n")
         for i, ref in enumerate(refs):
             log.color_print(f"{i + 1}. {ref.text[:60]}… {ref.reference}")


### PR DESCRIPTION
Fixes #246

## Problem

When running `deepsearcher query`, the final answer is printed twice to the console:

1. **First print**: Each agent (`DeepSearch`, `NaiveRAG`, `ChainOfRAG`) already prints `==== FINAL ANSWER====` and the answer content inside its own `query()` method as part of the streaming thought-process output.
2. **Second print**: `cli.py` then prints `==== FINAL ANSWER====` and the same answer again after `query()` returns.

The second print also includes a `### References` section with different content (references are shown the second time but not the first), making the duplication even more confusing.

## Solution

Remove the redundant `==== FINAL ANSWER====` header and answer body from `cli.py`. The agents already handle printing the answer. The `### References` section is kept in `cli.py` since it is not printed by the agents.

## Testing

Traced the execution path for `deepsearcher query "..."`:
- `cli.py` calls `online_query.query()` → `default_searcher.query()`
- Agents print `==== FINAL ANSWER====` + answer during execution
- `cli.py` no longer re-prints the same content; only appends the references list