### PR TITLE
fix: eliminate duplicate Configuration init and add --config CLI arg

### DIFF
--- a/deepsearcher/cli.py
+++ b/deepsearcher/cli.py
@@ -35,10 +35,13 @@ def main():
         )
         sys.exit(1)
 
-    config = Configuration()  # Customize your config here
-    init_config(config=config)
-
     parser = argparse.ArgumentParser(prog="deepsearcher", description="Deep Searcher.")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to a custom configuration YAML file. Defaults to the built-in config.yaml.",
+    )
     subparsers = parser.add_subparsers(dest="subcommand", title="subcommands")
 
     ## Arguments of query
@@ -87,6 +90,10 @@ def main():
     )
 
     args = parser.parse_args()
+
+    config = Configuration(config_path=args.config) if args.config else Configuration()
+    init_config(config=config)
+
     if args.subcommand == "query":
         final_answer, refs, consumed_tokens = query(args.query, max_iter=args.max_iter)
         log.color_print("\n==== FINAL ANSWER====\n")

--- a/deepsearcher/configuration.py
+++ b/deepsearcher/configuration.py
@@ -171,8 +171,6 @@ class ModuleFactory:
         return self._create_module_instance("vector_db", "deepsearcher.vector_db")
 
 
-config = Configuration()
-
 module_factory: ModuleFactory = None
 llm: BaseLLM = None
 embedding_model: BaseEmbedding = None


### PR DESCRIPTION
Fixes #197

## Problem

When any CLI command is executed, `Configuration()` is instantiated twice:

1. **First instantiation** — the module-level `config = Configuration()` in `configuration.py` fires as a side-effect of the import statement in `cli.py`.
2. **Second instantiation** — `cli.py` explicitly calls `config = Configuration()` before `init_config()`.

This is unnecessary: the module-level instance is never consumed by any code path — `online_query.py` and `offline_loading.py` access `configuration.default_searcher`, `configuration.vector_db`, etc., which are set only by `init_config()`.

## Solution

1. **Remove** the unused `config = Configuration()` module-level statement from `configuration.py`.
2. **Move** config initialization in `cli.py` to after argument parsing (avoids any startup overhead before the user's intent is known).
3. **Add** a `--config` flag to the CLI so users can specify a custom YAML path without editing source files, as suggested in the issue thread.

## Testing

- Verified `Configuration.__init__` is called exactly once when running a CLI command after the patch.
- Existing examples and `main.py` are unaffected — they always instantiated `Configuration()` themselves and passed it to `init_config()`.