### PR TITLE
fix: remove embedding vector from Milvus search output_fields

### DIFF
--- a/deepsearcher/vector_db/milvus.py
+++ b/deepsearcher/vector_db/milvus.py
@@ -223,7 +223,7 @@ class Milvus(BaseVectorDB):
                     reqs=[sparse_request, dense_request],
                     ranker=RRFRanker(),
                     limit=top_k,
-                    output_fields=["embedding", "text", "reference", "metadata"],
+                    output_fields=["text", "reference", "metadata"],
                     timeout=10,
                 )
             else:
@@ -231,13 +231,13 @@ class Milvus(BaseVectorDB):
                     collection_name=collection,
                     data=[vector],
                     limit=top_k,
-                    output_fields=["embedding", "text", "reference", "metadata"],
+                    output_fields=["text", "reference", "metadata"],
                     timeout=10,
                 )
 
             return [
                 RetrievalResult(
-                    embedding=b["entity"]["embedding"],
+                    embedding=None,
                     text=b["entity"]["text"],
                     reference=b["entity"]["reference"],
                     score=b["distance"],


### PR DESCRIPTION
Fixes #238

## Problem

In some Milvus configurations (e.g. Milvus docker standalone, Milvus server deployments), requesting the `embedding` vector field as an output field in `client.search()` raises:

```
MilvusException: (code=65535, message=field embedding not exist)
```

This causes `search_data()` to fail entirely, making the whole query pipeline crash with a `RuntimeError`.

## Root Cause

The `output_fields=["embedding", "text", "reference", "metadata"]` parameter requests the dense vector field back from Milvus. Some Milvus versions or server configurations do not support returning vector fields via `output_fields`, resulting in the above exception.

Importantly, `RetrievalResult.embedding` is **never used downstream** — it only appears in `__repr__()`. No agent code reads the embedding from search results, making this retrieval unnecessary and wasteful (embeddings can be thousands of floats per result).

## Solution

- Remove `"embedding"` from `output_fields` in both regular search and hybrid search calls
- Pass `None` for the `embedding` parameter when constructing `RetrievalResult`

This eliminates the exception, reduces data transfer from Milvus, and has no functional impact since the embedding value from search results is never consumed.

## Testing

Verified against existing `tests/vector_db/test_milvus.py` test suite — `test_search_data` passes as before since it only checks the result is a `RetrievalResult` instance, not its `embedding` value.