### PR TITLE
fix: guard against empty/filtered LLM responses in all provider clients

### DIFF
--- a/deepsearcher/llm/aliyun.py
+++ b/deepsearcher/llm/aliyun.py
@@ -60,6 +60,8 @@ class Aliyun(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=completion.choices[0].message.content,
             total_tokens=completion.usage.total_tokens,

--- a/deepsearcher/llm/azure_openai.py
+++ b/deepsearcher/llm/azure_openai.py
@@ -60,6 +60,8 @@ class AzureOpenAI(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=completion.choices[0].message.content,
             total_tokens=completion.usage.total_tokens,

--- a/deepsearcher/llm/deepseek.py
+++ b/deepsearcher/llm/deepseek.py
@@ -58,6 +58,8 @@ class DeepSeek(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=completion.choices[0].message.content,
             total_tokens=completion.usage.total_tokens,

--- a/deepsearcher/llm/glm.py
+++ b/deepsearcher/llm/glm.py
@@ -28,6 +28,8 @@ class GLM(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=completion.choices[0].message.content,
             total_tokens=completion.usage.total_tokens,

--- a/deepsearcher/llm/jiekouai.py
+++ b/deepsearcher/llm/jiekouai.py
@@ -55,6 +55,8 @@ class JiekouAI(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=completion.choices[0].message.content,
             total_tokens=completion.usage.total_tokens,

--- a/deepsearcher/llm/novita.py
+++ b/deepsearcher/llm/novita.py
@@ -28,6 +28,8 @@ class Novita(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=completion.choices[0].message.content,
             total_tokens=completion.usage.total_tokens,

--- a/deepsearcher/llm/openai_llm.py
+++ b/deepsearcher/llm/openai_llm.py
@@ -55,6 +55,8 @@ class OpenAI(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=completion.choices[0].message.content,
             total_tokens=completion.usage.total_tokens,

--- a/deepsearcher/llm/ppio.py
+++ b/deepsearcher/llm/ppio.py
@@ -55,6 +55,8 @@ class PPIO(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=completion.choices[0].message.content,
             total_tokens=completion.usage.total_tokens,

--- a/deepsearcher/llm/siliconflow.py
+++ b/deepsearcher/llm/siliconflow.py
@@ -57,6 +57,8 @@ class SiliconFlow(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=completion.choices[0].message.content,
             total_tokens=completion.usage.total_tokens,

--- a/deepsearcher/llm/together_ai.py
+++ b/deepsearcher/llm/together_ai.py
@@ -52,6 +52,8 @@ class TogetherAI(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=response.choices[0].message.content,
             total_tokens=response.usage.total_tokens,

--- a/deepsearcher/llm/volcengine.py
+++ b/deepsearcher/llm/volcengine.py
@@ -57,6 +57,8 @@ class Volcengine(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=completion.choices[0].message.content,
             total_tokens=completion.usage.total_tokens,

--- a/deepsearcher/llm/xai.py
+++ b/deepsearcher/llm/xai.py
@@ -57,6 +57,8 @@ class XAI(BaseLLM):
             model=self.model,
             messages=messages,
         )
+        if not completion.choices or completion.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return ChatResponse(
             content=completion.choices[0].message.content,
             total_tokens=completion.usage.total_tokens,


### PR DESCRIPTION
## What

Add null checks before `choices[0].message` in all 12 LLM provider files under `deepsearcher/llm/`:

`glm.py`, `novita.py`, `xai.py`, `ppio.py`, `together_ai.py`, `aliyun.py`, `openai_llm.py`, `jiekouai.py`, `azure_openai.py`, `deepseek.py`, `volcengine.py`, `siliconflow.py`

## Why

Two crash vectors exist at `completion.choices[0].message.content`:

1. **`IndexError`** — when `choices` is an empty list (network interruption, provider-side edge cases, some API-level errors that return HTTP 200 with an empty response body)
2. **`AttributeError`** — when `choices[0].message` is `None`. This is observed on Gemini via OpenAI-compatible endpoints when content is filtered (PROHIBITED_CONTENT), returning HTTP 200 with `message: null` instead of an HTTP error code. Other providers have similar behaviour.

## Fix

```python
if not completion.choices or completion.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
return ChatResponse(
    content=completion.choices[0].message.content,
    total_tokens=completion.usage.total_tokens,
)
```

No behaviour change for well-formed responses.