### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/deepsearcher/config.yaml
+++ b/deepsearcher/config.yaml
@@ -52,6 +52,12 @@ provide_settings:
 #      model: "deepseek/deepseek-v3-0324"
 ##      api_key: "sk_xxxxxx"  # Uncomment to override the `NOVITA_API_KEY` set in the environment variable
 
+#    provider: "LiteLLM"
+#    config:
+#      model: "anthropic/claude-sonnet-4-20250514"  # Any LiteLLM-supported model
+##      api_key: "sk-xxxx"  # Uncomment to override the `LITELLM_API_KEY` set in the environment variable
+##      api_base: "http://localhost:4000"  # Uncomment to use a LiteLLM proxy server
+
   embedding:
     provider: "OpenAIEmbedding"
     config:
@@ -104,6 +110,13 @@ provide_settings:
     # provider: "SentenceTransformerEmbedding"
     # config:
     #   model: "BAAI/bge-large-zh-v1.5"
+
+#    provider: "LiteLLMEmbedding"
+#    config:
+#      model: "text-embedding-ada-002"  # Any LiteLLM-supported embedding model
+##      api_key: "sk-xxxx"  # Uncomment to override the `LITELLM_API_KEY` set in the environment variable
+##      api_base: "http://localhost:4000"  # Uncomment to use a LiteLLM proxy server
+##      dimension: 1536
 
   file_loader:
     provider: "PDFLoader"

--- a/deepsearcher/embedding/__init__.py
+++ b/deepsearcher/embedding/__init__.py
@@ -3,6 +3,7 @@ from .fastembed_embdding import FastEmbedEmbedding
 from .gemini_embedding import GeminiEmbedding
 from .glm_embedding import GLMEmbedding
 from .jiekouai_embedding import JiekouAIEmbedding
+from .litellm_embedding import LiteLLMEmbedding
 from .milvus_embedding import MilvusEmbedding
 from .novita_embedding import NovitaEmbedding
 from .ollama_embedding import OllamaEmbedding
@@ -30,4 +31,5 @@ __all__ = [
     "SentenceTransformerEmbedding",
     "WatsonXEmbedding",
     "JiekouAIEmbedding",
+    "LiteLLMEmbedding",
 ]

--- a/deepsearcher/embedding/litellm_embedding.py
+++ b/deepsearcher/embedding/litellm_embedding.py
@@ -1,0 +1,109 @@
+import os
+from typing import List
+
+from deepsearcher.embedding.base import BaseEmbedding
+
+
+class LiteLLMEmbedding(BaseEmbedding):
+    """
+    LiteLLM embedding model implementation.
+
+    This class provides a unified interface to embedding models from 100+ providers
+    (OpenAI, Cohere, Bedrock, Vertex AI, and more) through the LiteLLM AI gateway.
+
+    API Documentation: https://docs.litellm.ai/docs/embedding/supported_embedding
+    """
+
+    def __init__(self, model: str = "text-embedding-ada-002", **kwargs):
+        """
+        Initialize the LiteLLM embedding model.
+
+        Args:
+            model (str): The model identifier to use for embeddings. Follows LiteLLM naming
+                conventions (e.g., "text-embedding-ada-002", "cohere/embed-english-v3.0",
+                "bedrock/amazon.titan-embed-text-v2:0"). Defaults to "text-embedding-ada-002".
+            **kwargs: Additional keyword arguments.
+                - api_key (str, optional): API key for the provider or LiteLLM proxy.
+                  If not provided, uses LITELLM_API_KEY environment variable.
+                  When not set, LiteLLM reads provider-specific env vars automatically.
+                - api_base (str, optional): Base URL for a LiteLLM proxy server.
+                  If not provided, uses LITELLM_API_BASE environment variable.
+                - dimension (int, optional): The dimension of the embedding vectors.
+                  Defaults to 1536.
+        """
+        self.model = model
+        if "api_key" in kwargs:
+            self.api_key = kwargs.pop("api_key")
+        else:
+            self.api_key = os.getenv("LITELLM_API_KEY")
+        if "api_base" in kwargs:
+            self.api_base = kwargs.pop("api_base")
+        else:
+            self.api_base = os.getenv("LITELLM_API_BASE")
+        if "dimension" in kwargs:
+            self.dim = kwargs.pop("dimension")
+        else:
+            self.dim = 1536
+        self.kwargs = kwargs
+
+    def embed_query(self, text: str) -> List[float]:
+        """
+        Embed a single query text.
+
+        Args:
+            text (str): The query text to embed.
+
+        Returns:
+            List[float]: A list of floats representing the embedding vector.
+        """
+        import litellm
+
+        kwargs = {**self.kwargs}
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+
+        response = litellm.embedding(
+            model=self.model,
+            input=[text],
+            drop_params=True,
+            **kwargs,
+        )
+        return response.data[0]["embedding"]
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """
+        Embed a list of document texts.
+
+        Args:
+            texts (List[str]): A list of document texts to embed.
+
+        Returns:
+            List[List[float]]: A list of embedding vectors, one for each input text.
+        """
+        import litellm
+
+        kwargs = {**self.kwargs}
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+
+        response = litellm.embedding(
+            model=self.model,
+            input=texts,
+            drop_params=True,
+            **kwargs,
+        )
+        return [r["embedding"] for r in response.data]
+
+    @property
+    def dimension(self) -> int:
+        """
+        Get the dimensionality of the embeddings.
+
+        Returns:
+            int: The number of dimensions in the embedding vectors.
+        """
+        return self.dim

--- a/deepsearcher/llm/__init__.py
+++ b/deepsearcher/llm/__init__.py
@@ -6,6 +6,7 @@ from .deepseek import DeepSeek
 from .gemini import Gemini
 from .glm import GLM
 from .jiekouai import JiekouAI
+from .litellm_llm import LiteLLM
 from .novita import Novita
 from .ollama import Ollama
 from .openai_llm import OpenAI
@@ -34,4 +35,5 @@ __all__ = [
     "Aliyun",
     "WatsonX",
     "JiekouAI",
+    "LiteLLM",
 ]

--- a/deepsearcher/llm/litellm_llm.py
+++ b/deepsearcher/llm/litellm_llm.py
@@ -1,0 +1,78 @@
+import os
+from typing import Dict, List
+
+from deepsearcher.llm.base import BaseLLM, ChatResponse
+
+
+class LiteLLM(BaseLLM):
+    """
+    LiteLLM language model implementation.
+
+    This class provides a unified interface to 100+ LLM providers (OpenAI, Anthropic,
+    Google, Azure, Bedrock, Ollama, and more) through the LiteLLM AI gateway.
+
+    API Documentation: https://docs.litellm.ai/docs/providers
+
+    Attributes:
+        model (str): The LiteLLM model identifier (e.g., "gpt-4o", "anthropic/claude-sonnet-4-20250514").
+        api_key (str): Optional API key. When not set, LiteLLM uses provider-specific
+            environment variables (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY).
+        api_base (str): Optional base URL for LiteLLM proxy or custom endpoints.
+    """
+
+    def __init__(self, model: str = "gpt-4o-mini", **kwargs):
+        """
+        Initialize a LiteLLM language model client.
+
+        Args:
+            model (str, optional): The model identifier to use. Follows LiteLLM naming
+                conventions (e.g., "gpt-4o", "anthropic/claude-sonnet-4-20250514",
+                "bedrock/anthropic.claude-v2"). Defaults to "gpt-4o-mini".
+            **kwargs: Additional keyword arguments passed to litellm.completion().
+                - api_key: API key for the provider or LiteLLM proxy.
+                  If not provided, uses LITELLM_API_KEY environment variable.
+                  When not set, LiteLLM reads provider-specific env vars automatically.
+                - api_base: Base URL for a LiteLLM proxy server.
+                  If not provided, uses LITELLM_API_BASE environment variable.
+        """
+        self.model = model
+        if "api_key" in kwargs:
+            self.api_key = kwargs.pop("api_key")
+        else:
+            self.api_key = os.getenv("LITELLM_API_KEY")
+        if "api_base" in kwargs:
+            self.api_base = kwargs.pop("api_base")
+        else:
+            self.api_base = os.getenv("LITELLM_API_BASE")
+        self.kwargs = kwargs
+
+    def chat(self, messages: List[Dict]) -> ChatResponse:
+        """
+        Send a chat message to the language model and get a response.
+
+        Args:
+            messages (List[Dict]): A list of message dictionaries, typically in the format
+                                  [{"role": "system", "content": "..."},
+                                   {"role": "user", "content": "..."}]
+
+        Returns:
+            ChatResponse: An object containing the model's response and token usage information.
+        """
+        import litellm
+
+        kwargs = {**self.kwargs}
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+
+        response = litellm.completion(
+            model=self.model,
+            messages=messages,
+            drop_params=True,
+            **kwargs,
+        )
+        return ChatResponse(
+            content=response.choices[0].message.content,
+            total_tokens=response.usage.total_tokens,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,8 @@ all = [
     "docling-core>=2.30.0",
     "crawl4ai>=0.6.2",
     "sentence-transformers>=4.1.0",
-    "ibm-watsonx-ai>=1.3.0"
+    "ibm-watsonx-ai>=1.3.0",
+    "litellm>=1.80.0,<1.87.0"
 ]
 
 voyageai = [
@@ -112,6 +113,10 @@ sentence-transformers = [
 
 ibm-watsonx = [
     "ibm-watsonx-ai>=1.3.0"
+]
+
+litellm = [
+    "litellm>=1.80.0,<1.87.0",
 ]
 
 [build-system]

--- a/tests/embedding/test_litellm_embedding.py
+++ b/tests/embedding/test_litellm_embedding.py
@@ -1,0 +1,134 @@
+import logging
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+logging.disable(logging.CRITICAL)
+
+from deepsearcher.embedding import LiteLLMEmbedding
+
+
+class TestLiteLLMEmbedding(unittest.TestCase):
+    """Tests for the LiteLLMEmbedding class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_litellm = MagicMock()
+
+        mock_data_item = {"embedding": [0.1] * 1536}
+        self.mock_response = MagicMock()
+        self.mock_response.data = [mock_data_item]
+        self.mock_litellm.embedding.return_value = self.mock_response
+
+        self.module_patcher = patch.dict("sys.modules", {"litellm": self.mock_litellm})
+        self.module_patcher.start()
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.module_patcher.stop()
+
+    def test_init_default(self):
+        """Test initialization with default parameters."""
+        with patch.dict("os.environ", {}, clear=True):
+            embedding = LiteLLMEmbedding()
+            self.assertEqual(embedding.model, "text-embedding-ada-002")
+            self.assertEqual(embedding.dim, 1536)
+            self.assertIsNone(embedding.api_key)
+            self.assertIsNone(embedding.api_base)
+
+    def test_init_with_env_vars(self):
+        """Test initialization with environment variables."""
+        with patch.dict(
+            os.environ,
+            {"LITELLM_API_KEY": "test-key", "LITELLM_API_BASE": "http://localhost:4000"},
+        ):
+            embedding = LiteLLMEmbedding()
+            self.assertEqual(embedding.api_key, "test-key")
+            self.assertEqual(embedding.api_base, "http://localhost:4000")
+
+    def test_init_with_parameters(self):
+        """Test initialization with parameters."""
+        with patch.dict("os.environ", {}, clear=True):
+            embedding = LiteLLMEmbedding(
+                model="cohere/embed-english-v3.0",
+                api_key="param-key",
+                api_base="http://proxy:4000",
+                dimension=1024,
+            )
+            self.assertEqual(embedding.model, "cohere/embed-english-v3.0")
+            self.assertEqual(embedding.api_key, "param-key")
+            self.assertEqual(embedding.api_base, "http://proxy:4000")
+            self.assertEqual(embedding.dim, 1024)
+
+    def test_embed_query(self):
+        """Test embedding a single query."""
+        with patch.dict("os.environ", {}, clear=True):
+            embedding = LiteLLMEmbedding()
+
+        result = embedding.embed_query("test query")
+
+        self.mock_litellm.embedding.assert_called_once_with(
+            model="text-embedding-ada-002",
+            input=["test query"],
+            drop_params=True,
+        )
+        self.assertEqual(result, [0.1] * 1536)
+
+    def test_embed_documents(self):
+        """Test embedding multiple documents."""
+        mock_data_items = [
+            {"embedding": [0.1 * (i + 1)] * 1536} for i in range(3)
+        ]
+        self.mock_response.data = mock_data_items
+
+        with patch.dict("os.environ", {}, clear=True):
+            embedding = LiteLLMEmbedding()
+
+        texts = ["text 1", "text 2", "text 3"]
+        results = embedding.embed_documents(texts)
+
+        self.mock_litellm.embedding.assert_called_once_with(
+            model="text-embedding-ada-002",
+            input=texts,
+            drop_params=True,
+        )
+        self.assertEqual(len(results), 3)
+
+    def test_embed_query_with_credentials(self):
+        """Test embed_query passes api_key and api_base when set."""
+        with patch.dict("os.environ", {}, clear=True):
+            embedding = LiteLLMEmbedding(api_key="my-key", api_base="http://proxy:4000")
+
+        embedding.embed_query("test")
+
+        self.mock_litellm.embedding.assert_called_once_with(
+            model="text-embedding-ada-002",
+            input=["test"],
+            drop_params=True,
+            api_key="my-key",
+            api_base="http://proxy:4000",
+        )
+
+    def test_embed_query_omits_credentials_when_not_set(self):
+        """Test embed_query omits api_key and api_base when not set."""
+        with patch.dict("os.environ", {}, clear=True):
+            embedding = LiteLLMEmbedding()
+
+        embedding.embed_query("test")
+
+        call_kwargs = self.mock_litellm.embedding.call_args[1]
+        self.assertNotIn("api_key", call_kwargs)
+        self.assertNotIn("api_base", call_kwargs)
+
+    def test_dimension_property(self):
+        """Test the dimension property."""
+        with patch.dict("os.environ", {}, clear=True):
+            embedding = LiteLLMEmbedding()
+            self.assertEqual(embedding.dimension, 1536)
+
+            embedding = LiteLLMEmbedding(dimension=768)
+            self.assertEqual(embedding.dimension, 768)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/llm/test_litellm.py
+++ b/tests/llm/test_litellm.py
@@ -1,0 +1,164 @@
+import logging
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+logging.disable(logging.CRITICAL)
+
+from deepsearcher.llm.base import ChatResponse
+from deepsearcher.llm import LiteLLM
+
+
+class TestLiteLLM(unittest.TestCase):
+    """Tests for the LiteLLM LLM provider."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_litellm = MagicMock()
+
+        self.mock_response = MagicMock()
+        self.mock_choice = MagicMock()
+        self.mock_message = MagicMock()
+        self.mock_usage = MagicMock()
+
+        self.mock_message.content = "Test response"
+        self.mock_choice.message = self.mock_message
+        self.mock_usage.total_tokens = 100
+
+        self.mock_response.choices = [self.mock_choice]
+        self.mock_response.usage = self.mock_usage
+        self.mock_litellm.completion.return_value = self.mock_response
+
+        self.module_patcher = patch.dict("sys.modules", {"litellm": self.mock_litellm})
+        self.module_patcher.start()
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.module_patcher.stop()
+
+    def test_init_default(self):
+        """Test initialization with default parameters."""
+        with patch.dict("os.environ", {}, clear=True):
+            llm = LiteLLM()
+            self.assertEqual(llm.model, "gpt-4o-mini")
+            self.assertIsNone(llm.api_key)
+            self.assertIsNone(llm.api_base)
+
+    def test_init_with_api_key_from_env(self):
+        """Test initialization with API key from environment variable."""
+        with patch.dict(
+            os.environ,
+            {"LITELLM_API_KEY": "test-key", "LITELLM_API_BASE": "http://localhost:4000"},
+        ):
+            llm = LiteLLM()
+            self.assertEqual(llm.api_key, "test-key")
+            self.assertEqual(llm.api_base, "http://localhost:4000")
+
+    def test_init_with_api_key_parameter(self):
+        """Test initialization with API key as parameter."""
+        with patch.dict("os.environ", {}, clear=True):
+            llm = LiteLLM(api_key="param-key", api_base="http://proxy:4000")
+            self.assertEqual(llm.api_key, "param-key")
+            self.assertEqual(llm.api_base, "http://proxy:4000")
+
+    def test_init_with_custom_model(self):
+        """Test initialization with custom model."""
+        with patch.dict("os.environ", {}, clear=True):
+            llm = LiteLLM(model="anthropic/claude-sonnet-4-20250514")
+            self.assertEqual(llm.model, "anthropic/claude-sonnet-4-20250514")
+
+    def test_chat_single_message(self):
+        """Test chat with a single message."""
+        with patch.dict("os.environ", {}, clear=True):
+            llm = LiteLLM()
+
+        messages = [{"role": "user", "content": "Hello"}]
+        response = llm.chat(messages)
+
+        self.mock_litellm.completion.assert_called_once_with(
+            model="gpt-4o-mini",
+            messages=messages,
+            drop_params=True,
+        )
+
+        self.assertIsInstance(response, ChatResponse)
+        self.assertEqual(response.content, "Test response")
+        self.assertEqual(response.total_tokens, 100)
+
+    def test_chat_multiple_messages(self):
+        """Test chat with multiple messages."""
+        with patch.dict("os.environ", {}, clear=True):
+            llm = LiteLLM()
+
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        response = llm.chat(messages)
+
+        self.mock_litellm.completion.assert_called_once_with(
+            model="gpt-4o-mini",
+            messages=messages,
+            drop_params=True,
+        )
+
+        self.assertIsInstance(response, ChatResponse)
+        self.assertEqual(response.content, "Test response")
+        self.assertEqual(response.total_tokens, 100)
+
+    def test_chat_with_api_key(self):
+        """Test chat passes api_key and api_base when set."""
+        with patch.dict("os.environ", {}, clear=True):
+            llm = LiteLLM(api_key="my-key", api_base="http://proxy:4000")
+
+        messages = [{"role": "user", "content": "Hello"}]
+        llm.chat(messages)
+
+        self.mock_litellm.completion.assert_called_once_with(
+            model="gpt-4o-mini",
+            messages=messages,
+            drop_params=True,
+            api_key="my-key",
+            api_base="http://proxy:4000",
+        )
+
+    def test_chat_omits_credentials_when_not_set(self):
+        """Test chat omits api_key and api_base when not set."""
+        with patch.dict("os.environ", {}, clear=True):
+            llm = LiteLLM()
+
+        messages = [{"role": "user", "content": "Hello"}]
+        llm.chat(messages)
+
+        call_kwargs = self.mock_litellm.completion.call_args[1]
+        self.assertNotIn("api_key", call_kwargs)
+        self.assertNotIn("api_base", call_kwargs)
+
+    def test_chat_with_error(self):
+        """Test chat when an error occurs."""
+        with patch.dict("os.environ", {}, clear=True):
+            llm = LiteLLM()
+
+        self.mock_litellm.completion.side_effect = Exception("LiteLLM API Error")
+
+        messages = [{"role": "user", "content": "Hello"}]
+        with self.assertRaises(Exception) as context:
+            llm.chat(messages)
+
+        self.assertEqual(str(context.exception), "LiteLLM API Error")
+
+    def test_drop_params_always_true(self):
+        """Test that drop_params=True is always passed."""
+        with patch.dict("os.environ", {}, clear=True):
+            llm = LiteLLM()
+
+        llm.chat([{"role": "user", "content": "Hello"}])
+
+        call_kwargs = self.mock_litellm.completion.call_args[1]
+        self.assertTrue(call_kwargs["drop_params"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary                                                                                                                                                                              
  - Adds LiteLLM as both an LLM and embedding provider, giving DeepSearcher users unified access to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, Bedrock, Ollama, and more)
  through a single interface.                                                                                                                                                             
  - LiteLLM is added as an optional dependency (`deepsearcher[litellm]`), keeping the default install lightweight.
                                                                                                                                                                                          
  ## Motivation   
  DeepSearcher already supports 18 LLM providers, each requiring a separate SDK and configuration. LiteLLM provides a unified gateway that routes to any provider using a single API,     
  reducing the need to maintain per-provider code. Users who already run a LiteLLM proxy get instant access to all their configured models.                                               
   
  ## Changes                                                                                                                                                                              
  - `deepsearcher/llm/litellm_llm.py` - New `LiteLLM` class implementing `BaseLLM`
  - `deepsearcher/embedding/litellm_embedding.py` - New `LiteLLMEmbedding` class implementing `BaseEmbedding`                                                                             
  - `deepsearcher/llm/__init__.py` - Registered `LiteLLM` provider                                                                                                                        
  - `deepsearcher/embedding/__init__.py` - Registered `LiteLLMEmbedding` provider                                                                                                         
  - `pyproject.toml` - Added `litellm>=1.80.0,<1.87.0` as optional dependency                                                                                                             
  - `deepsearcher/config.yaml` - Added commented configuration examples                                                                                                                   
  - `tests/llm/test_litellm.py` - 10 unit tests for LLM provider                                                                                                                          
  - `tests/embedding/test_litellm_embedding.py` - 8 unit tests for embedding provider                                                                                                     
                                                                                                                                                                                          
  ## Proof of work
                                                                                                                                                                                          
  **Unit tests (18/18 passing):**                                                                                                                                                         
  tests/llm/test_litellm.py::TestLiteLLM::test_chat_multiple_messages PASSED
  tests/llm/test_litellm.py::TestLiteLLM::test_chat_omits_credentials_when_not_set PASSED                                                                                                 
  tests/llm/test_litellm.py::TestLiteLLM::test_chat_single_message PASSED                
  tests/llm/test_litellm.py::TestLiteLLM::test_chat_with_api_key PASSED                                                                                                                   
  tests/llm/test_litellm.py::TestLiteLLM::test_chat_with_error PASSED  
  tests/llm/test_litellm.py::TestLiteLLM::test_drop_params_always_true PASSED                                                                                                             
  tests/llm/test_litellm.py::TestLiteLLM::test_init_default PASSED           
  tests/llm/test_litellm.py::TestLiteLLM::test_init_with_api_key_from_env PASSED                                                                                                          
  tests/llm/test_litellm.py::TestLiteLLM::test_init_with_api_key_parameter PASSED
  tests/llm/test_litellm.py::TestLiteLLM::test_init_with_custom_model PASSED                                                                                                              
  tests/embedding/test_litellm_embedding.py::TestLiteLLMEmbedding::test_dimension_property PASSED
  tests/embedding/test_litellm_embedding.py::TestLiteLLMEmbedding::test_embed_documents PASSED                                                                                            
  tests/embedding/test_litellm_embedding.py::TestLiteLLMEmbedding::test_embed_query PASSED    
  tests/embedding/test_litellm_embedding.py::TestLiteLLMEmbedding::test_embed_query_omits_credentials_when_not_set PASSED                                                                 
  tests/embedding/test_litellm_embedding.py::TestLiteLLMEmbedding::test_embed_query_with_credentials PASSED              
  tests/embedding/test_litellm_embedding.py::TestLiteLLMEmbedding::test_init_default PASSED                                                                                               
  tests/embedding/test_litellm_embedding.py::TestLiteLLMEmbedding::test_init_with_env_vars PASSED                                                                                         
  tests/embedding/test_litellm_embedding.py::TestLiteLLMEmbedding::test_init_with_parameters PASSED                                                                                       
                                                                                                                                                                                          
  18 passed       
                                                                                                                                                                                          
  **Lint:** `ruff check` and `ruff format --check` both pass clean.
                                                                                                                                                                                          
  ## Implementation notes                                                                                                                                                                 
  - `drop_params=True` is always set so provider-unsupported kwargs (e.g., `seed`, `frequency_penalty` on Anthropic) are silently dropped instead of causing errors.
  - `api_key` and `api_base` are only forwarded when set. When omitted, LiteLLM reads provider-specific environment variables automatically (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`).
  - `litellm` is lazy-imported inside method bodies so users who don't install it are unaffected.                                                                                         
                                                                                                                                                                                          
  ## Risk / Compatibility                                                                                                                                                                 
  - Additive only. Existing providers untouched.                                                                                                                                          
  - `litellm` is an optional extra - base install unaffected.                                                                                                                             
                                                                                                                                                                                          
  ## Example usage                                                                                                                                                                        
                                                                                                                                                                                          
  ```yaml         
  # config.yaml
  provide_settings:
    llm:                                                                                                                                                                                  
      provider: "LiteLLM"
      config:                                                                                                                                                                             
        model: "anthropic/claude-sonnet-4-20250514"
        # api_key: "sk-xxxx"  # or set ANTHROPIC_API_KEY env var                                                                                                                          
  
    embedding:                                                                                                                                                                            
      provider: "LiteLLMEmbedding"
      config:                                                                                                                                                                             
        model: "text-embedding-ada-002"
        dimension: 1536
```

```python
  from deepsearcher.llm import LiteLLM
  from deepsearcher.embedding import LiteLLMEmbedding                                                                                                                                     
  
  # LLM - uses ANTHROPIC_API_KEY from environment                                                                                                                                         
  llm = LiteLLM(model="anthropic/claude-sonnet-4-20250514")
  response = llm.chat([{"role": "user", "content": "What is 2+2?"}])                                                                                                                      
  print(response.content)                                                                                                                                                                 
  
  # Embedding - uses OPENAI_API_KEY from environment                                                                                                                                      
  embedding = LiteLLMEmbedding(model="text-embedding-ada-002")
  vector = embedding.embed_query("Hello world")                                                                                                                                           
  print(f"Dimension: {len(vector)}")
  ```