### PR TITLE
feat: add fastCRW crawler

### DIFF
--- a/deepsearcher/loader/web_crawler/__init__.py
+++ b/deepsearcher/loader/web_crawler/__init__.py
@@ -1,10 +1,12 @@
 from deepsearcher.loader.web_crawler.crawl4ai_crawler import Crawl4AICrawler
+from deepsearcher.loader.web_crawler.crw_crawler import CrwCrawler
 from deepsearcher.loader.web_crawler.docling_crawler import DoclingCrawler
 from deepsearcher.loader.web_crawler.firecrawl_crawler import FireCrawlCrawler
 from deepsearcher.loader.web_crawler.jina_crawler import JinaCrawler
 
 __all__ = [
     "FireCrawlCrawler",
+    "CrwCrawler",
     "JinaCrawler",
     "Crawl4AICrawler",
     "DoclingCrawler",

--- a/deepsearcher/loader/web_crawler/crw_crawler.py
+++ b/deepsearcher/loader/web_crawler/crw_crawler.py
@@ -1,0 +1,100 @@
+import os
+from typing import List, Optional
+
+from firecrawl import FirecrawlApp, ScrapeOptions
+from langchain_core.documents import Document
+
+from deepsearcher.loader.web_crawler.base import BaseCrawler
+
+# Default fastCRW cloud base URL. Override for self-hosted deployments
+# (e.g. "http://localhost:3000") via the CRW_API_URL environment variable.
+DEFAULT_CRW_API_URL = "https://fastcrw.com/api"
+
+
+class CrwCrawler(BaseCrawler):
+    """
+    Web crawler using the fastCRW service.
+
+    fastCRW is a Firecrawl-compatible web scraper packaged as a single Rust binary
+    (self-host or managed cloud). Because its API is Firecrawl-compatible, this
+    crawler reuses the Firecrawl client and simply points it at the fastCRW base URL.
+
+    This crawler converts web pages into markdown format for further processing.
+    It supports both single-page scraping and recursive crawling of multiple pages.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initialize the CrwCrawler.
+
+        Args:
+            **kwargs: Optional keyword arguments.
+        """
+        super().__init__(**kwargs)
+        self.app = None
+
+    def crawl_url(
+        self,
+        url: str,
+        max_depth: Optional[int] = None,
+        limit: Optional[int] = None,
+        allow_backward_links: Optional[bool] = None,
+    ) -> List[Document]:
+        """
+        Dynamically crawls a URL using either scrape_url or crawl_url:
+
+        - Uses scrape_url for single-page extraction if no params are provided.
+        - Uses crawl_url to recursively gather pages when any param is provided.
+
+        Args:
+            url (str): The starting URL to crawl.
+            max_depth (Optional[int]): Maximum depth for recursive crawling (default: 2).
+            limit (Optional[int]): Maximum number of pages to crawl (default: 20).
+            allow_backward_links (Optional[bool]): Allow crawling pages outside the URL's children (default: False).
+
+        Returns:
+            List[Document]: List of Document objects with page content and metadata.
+        """
+        # Lazy init. Point the Firecrawl-compatible client at the fastCRW base URL.
+        # CRW_API_URL overrides the default (e.g. for self-hosted servers); the
+        # self-hosted engine may require no key, so CRW_API_KEY is optional.
+        self.app = FirecrawlApp(
+            api_key=os.getenv("CRW_API_KEY"),
+            api_url=os.getenv("CRW_API_URL", DEFAULT_CRW_API_URL),
+        )
+
+        # if user just inputs a single url as param
+        # scrape single page
+        if max_depth is None and limit is None and allow_backward_links is None:
+            # Call the new Firecrawl API, passing formats directly
+            scrape_response = self.app.scrape_url(url=url, formats=["markdown"])
+            data = scrape_response.model_dump()
+            return [
+                Document(
+                    page_content=data.get("markdown", ""),
+                    metadata={"reference": url, **data.get("metadata", {})},
+                )
+            ]
+
+        # else, crawl multiple pages based on users' input params
+        # set default values if not provided
+        crawl_response = self.app.crawl_url(
+            url=url,
+            limit=limit or 20,
+            max_depth=max_depth or 2,
+            allow_backward_links=allow_backward_links or False,
+            scrape_options=ScrapeOptions(formats=["markdown"]),
+            poll_interval=5,
+        )
+        items = crawl_response.model_dump().get("data", [])
+
+        documents: List[Document] = []
+        for item in items:
+            # Support items that are either dicts or Pydantic sub-models
+            item_dict = item.model_dump() if hasattr(item, "model_dump") else item
+            md = item_dict.get("markdown", "")
+            meta = item_dict.get("metadata", {})
+            meta["reference"] = meta.get("url", url)
+            documents.append(Document(page_content=md, metadata=meta))
+
+        return documents

--- a/tests/loader/web_crawler/test_crw_crawler.py
+++ b/tests/loader/web_crawler/test_crw_crawler.py
@@ -1,0 +1,158 @@
+import unittest
+import os
+from unittest.mock import patch, MagicMock
+
+from langchain_core.documents import Document
+
+from deepsearcher.loader.web_crawler import CrwCrawler
+
+
+class TestCrwCrawler(unittest.TestCase):
+    """Tests for the CrwCrawler class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Patch the environment variable
+        self.env_patcher = patch.dict('os.environ', {'CRW_API_KEY': 'fake-api-key'})
+        self.env_patcher.start()
+
+        # Create a mock for the FirecrawlApp (fastCRW is Firecrawl-compatible)
+        self.crw_app_patcher = patch('deepsearcher.loader.web_crawler.crw_crawler.FirecrawlApp')
+        self.mock_crw_app = self.crw_app_patcher.start()
+
+        # Set up mock instances
+        self.mock_app_instance = MagicMock()
+        self.mock_crw_app.return_value = self.mock_app_instance
+
+        # Create the crawler
+        self.crawler = CrwCrawler()
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.env_patcher.stop()
+        self.crw_app_patcher.stop()
+
+    def test_init(self):
+        """Test initialization."""
+        self.assertIsNone(self.crawler.app)
+
+    def test_crawl_url_single_page(self):
+        """Test crawling a single URL."""
+        url = "https://example.com"
+
+        # Set up mock response for scrape_url
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "markdown": "# Example Page\nThis is a test page.",
+            "metadata": {"title": "Example Page", "url": url}
+        }
+        self.mock_app_instance.scrape_url.return_value = mock_response
+
+        # Call the method
+        documents = self.crawler.crawl_url(url)
+
+        # Verify FirecrawlApp was initialized against the fastCRW base URL
+        self.mock_crw_app.assert_called_once_with(
+            api_key='fake-api-key', api_url='https://fastcrw.com/api'
+        )
+
+        # Verify scrape_url was called correctly
+        self.mock_app_instance.scrape_url.assert_called_once_with(url=url, formats=["markdown"])
+
+        # Check results
+        self.assertEqual(len(documents), 1)
+        document = documents[0]
+        self.assertEqual(document.page_content, "# Example Page\nThis is a test page.")
+        self.assertEqual(document.metadata["reference"], url)
+        self.assertEqual(document.metadata["title"], "Example Page")
+
+    def test_crawl_url_multiple_pages(self):
+        """Test crawling multiple pages recursively."""
+        url = "https://example.com"
+        max_depth = 3
+        limit = 10
+
+        # Set up mock response for crawl_url
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "data": [
+                {
+                    "markdown": "# Page 1\nContent 1",
+                    "metadata": {"title": "Page 1", "url": "https://example.com/page1"}
+                },
+                {
+                    "markdown": "# Page 2\nContent 2",
+                    "metadata": {"title": "Page 2", "url": "https://example.com/page2"}
+                }
+            ]
+        }
+        self.mock_app_instance.crawl_url.return_value = mock_response
+
+        # Call the method
+        documents = self.crawler.crawl_url(url, max_depth=max_depth, limit=limit)
+
+        # Verify FirecrawlApp was initialized against the fastCRW base URL
+        self.mock_crw_app.assert_called_once_with(
+            api_key='fake-api-key', api_url='https://fastcrw.com/api'
+        )
+
+        # Verify crawl_url was called correctly
+        self.mock_app_instance.crawl_url.assert_called_once()
+        call_kwargs = self.mock_app_instance.crawl_url.call_args[1]
+        self.assertEqual(call_kwargs['url'], url)
+        self.assertEqual(call_kwargs['max_depth'], max_depth)
+        self.assertEqual(call_kwargs['limit'], limit)
+
+        # Check results
+        self.assertEqual(len(documents), 2)
+
+        # Check first document
+        self.assertEqual(documents[0].page_content, "# Page 1\nContent 1")
+        self.assertEqual(documents[0].metadata["reference"], "https://example.com/page1")
+        self.assertEqual(documents[0].metadata["title"], "Page 1")
+
+        # Check second document
+        self.assertEqual(documents[1].page_content, "# Page 2\nContent 2")
+        self.assertEqual(documents[1].metadata["reference"], "https://example.com/page2")
+        self.assertEqual(documents[1].metadata["title"], "Page 2")
+
+    def test_crawl_url_with_default_params(self):
+        """Test crawling with default parameters."""
+        url = "https://example.com"
+
+        # Set up mock response for crawl_url
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {"data": []}
+        self.mock_app_instance.crawl_url.return_value = mock_response
+
+        # Call the method with only max_depth
+        self.crawler.crawl_url(url, max_depth=2)
+
+        # Verify default values were used
+        call_kwargs = self.mock_app_instance.crawl_url.call_args[1]
+        self.assertEqual(call_kwargs['limit'], 20)  # Default limit
+        self.assertEqual(call_kwargs['max_depth'], 2)  # Provided max_depth
+        self.assertEqual(call_kwargs['allow_backward_links'], False)  # Default allow_backward_links
+
+    def test_crawl_url_self_host_override(self):
+        """Test that CRW_API_URL overrides the default cloud base URL."""
+        url = "https://example.com"
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "markdown": "# Self Host",
+            "metadata": {"url": url}
+        }
+        self.mock_app_instance.scrape_url.return_value = mock_response
+
+        with patch.dict('os.environ', {'CRW_API_URL': 'http://localhost:3000'}):
+            self.crawler.crawl_url(url)
+
+        # Verify FirecrawlApp was initialized against the self-hosted base URL
+        self.mock_crw_app.assert_called_once_with(
+            api_key='fake-api-key', api_url='http://localhost:3000'
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/loader/web_crawler/test_crw_crawler.py
+++ b/tests/loader/web_crawler/test_crw_crawler.py
@@ -1,8 +1,5 @@
 import unittest
-import os
-from unittest.mock import patch, MagicMock
-
-from langchain_core.documents import Document
+from unittest.mock import MagicMock, patch
 
 from deepsearcher.loader.web_crawler import CrwCrawler
 
@@ -13,11 +10,11 @@ class TestCrwCrawler(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         # Patch the environment variable
-        self.env_patcher = patch.dict('os.environ', {'CRW_API_KEY': 'fake-api-key'})
+        self.env_patcher = patch.dict("os.environ", {"CRW_API_KEY": "fake-api-key"})
         self.env_patcher.start()
 
         # Create a mock for the FirecrawlApp (fastCRW is Firecrawl-compatible)
-        self.crw_app_patcher = patch('deepsearcher.loader.web_crawler.crw_crawler.FirecrawlApp')
+        self.crw_app_patcher = patch("deepsearcher.loader.web_crawler.crw_crawler.FirecrawlApp")
         self.mock_crw_app = self.crw_app_patcher.start()
 
         # Set up mock instances
@@ -44,7 +41,7 @@ class TestCrwCrawler(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.model_dump.return_value = {
             "markdown": "# Example Page\nThis is a test page.",
-            "metadata": {"title": "Example Page", "url": url}
+            "metadata": {"title": "Example Page", "url": url},
         }
         self.mock_app_instance.scrape_url.return_value = mock_response
 
@@ -53,7 +50,7 @@ class TestCrwCrawler(unittest.TestCase):
 
         # Verify FirecrawlApp was initialized against the fastCRW base URL
         self.mock_crw_app.assert_called_once_with(
-            api_key='fake-api-key', api_url='https://fastcrw.com/api'
+            api_key="fake-api-key", api_url="https://fastcrw.com/api"
         )
 
         # Verify scrape_url was called correctly
@@ -78,12 +75,12 @@ class TestCrwCrawler(unittest.TestCase):
             "data": [
                 {
                     "markdown": "# Page 1\nContent 1",
-                    "metadata": {"title": "Page 1", "url": "https://example.com/page1"}
+                    "metadata": {"title": "Page 1", "url": "https://example.com/page1"},
                 },
                 {
                     "markdown": "# Page 2\nContent 2",
-                    "metadata": {"title": "Page 2", "url": "https://example.com/page2"}
-                }
+                    "metadata": {"title": "Page 2", "url": "https://example.com/page2"},
+                },
             ]
         }
         self.mock_app_instance.crawl_url.return_value = mock_response
@@ -93,15 +90,15 @@ class TestCrwCrawler(unittest.TestCase):
 
         # Verify FirecrawlApp was initialized against the fastCRW base URL
         self.mock_crw_app.assert_called_once_with(
-            api_key='fake-api-key', api_url='https://fastcrw.com/api'
+            api_key="fake-api-key", api_url="https://fastcrw.com/api"
         )
 
         # Verify crawl_url was called correctly
         self.mock_app_instance.crawl_url.assert_called_once()
         call_kwargs = self.mock_app_instance.crawl_url.call_args[1]
-        self.assertEqual(call_kwargs['url'], url)
-        self.assertEqual(call_kwargs['max_depth'], max_depth)
-        self.assertEqual(call_kwargs['limit'], limit)
+        self.assertEqual(call_kwargs["url"], url)
+        self.assertEqual(call_kwargs["max_depth"], max_depth)
+        self.assertEqual(call_kwargs["limit"], limit)
 
         # Check results
         self.assertEqual(len(documents), 2)
@@ -130,9 +127,9 @@ class TestCrwCrawler(unittest.TestCase):
 
         # Verify default values were used
         call_kwargs = self.mock_app_instance.crawl_url.call_args[1]
-        self.assertEqual(call_kwargs['limit'], 20)  # Default limit
-        self.assertEqual(call_kwargs['max_depth'], 2)  # Provided max_depth
-        self.assertEqual(call_kwargs['allow_backward_links'], False)  # Default allow_backward_links
+        self.assertEqual(call_kwargs["limit"], 20)  # Default limit
+        self.assertEqual(call_kwargs["max_depth"], 2)  # Provided max_depth
+        self.assertEqual(call_kwargs["allow_backward_links"], False)  # Default allow_backward_links
 
     def test_crawl_url_self_host_override(self):
         """Test that CRW_API_URL overrides the default cloud base URL."""
@@ -141,16 +138,16 @@ class TestCrwCrawler(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.model_dump.return_value = {
             "markdown": "# Self Host",
-            "metadata": {"url": url}
+            "metadata": {"url": url},
         }
         self.mock_app_instance.scrape_url.return_value = mock_response
 
-        with patch.dict('os.environ', {'CRW_API_URL': 'http://localhost:3000'}):
+        with patch.dict("os.environ", {"CRW_API_URL": "http://localhost:3000"}):
             self.crawler.crawl_url(url)
 
         # Verify FirecrawlApp was initialized against the self-hosted base URL
         self.mock_crw_app.assert_called_once_with(
-            api_key='fake-api-key', api_url='http://localhost:3000'
+            api_key="fake-api-key", api_url="http://localhost:3000"
         )
 
 


### PR DESCRIPTION
## What
Adds **fastCRW** as a web scrape/search provider, alongside the existing Firecrawl integration — additive, mirrors the Firecrawl wiring (Firecrawl untouched).

## Why
[fastCRW](https://fastcrw.com) is a fully open-source (AGPL) web scraping engine that ships everything in the open core — anti-bot/stealth bypass, JS rendering, UA rotation, BYO-proxy + rotation, and an HTTP→headless→proxy fallback ladder, all in a single ~8MB Rust binary at ~6MB RAM. No cloud dependency, no multi-service stack.

This matters for deep research workloads: Firecrawl's OSS self-host gates its stealth engine (`fire-engine`) behind a cloud-only flag, so a self-hosted Firecrawl silently falls back to plain fetch/Playwright and can't reach protected or JS-heavy sites. fastCRW's open core handles those natively.

On Firecrawl's own benchmark dataset, fastCRW scores higher truth-recall (63.74% vs 56.04%) and lower median latency (p50 ~1.9s vs ~2.3s).

On web search specifically: crw is not an alternative to SearXNG — it is built on top of it. SearXNG is the metasearch aggregator underneath; crw adds a quality layer on top: query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content instead of SearXNG's content-blind ordering), a calibrated direct-answer mode, and category routing (research queries fan out to arxiv / semantic scholar / google scholar, code queries to GitHub). So you get SearXNG's breadth plus a measurable accuracy layer, all open-source (AGPL) and self-hostable with configurable engines.

Key via `CRW_API_KEY` (free tier at https://fastcrw.com/dashboard); self-host base URL supported. Because fastCRW implements the Firecrawl API, the integration is a small additive diff with no changes to the existing Firecrawl provider. Happy to adjust to your conventions — I maintain the integration and can provide free credits to evaluate.
