### PR TITLE
feat(llm): add Atlas Cloud LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ result = query("Write a report about xxx.") # Your question here
 #### LLM Configuration
 
 <pre><code>config.set_provider_config("llm", "(LLMName)", "(Arguments dict)")</code></pre>
-<p>The "LLMName" can be one of the following: ["DeepSeek", "OpenAI", "XAI", "SiliconFlow", "Aliyun", "PPIO", "TogetherAI", "Gemini", "Ollama", "Novita", "Jiekou.AI"]</p>
+<p>The "LLMName" can be one of the following: ["DeepSeek", "OpenAI", "XAI", "SiliconFlow", "Aliyun", "PPIO", "TogetherAI", "Gemini", "Ollama", "Novita", "Jiekou.AI", "AtlasCloud"]</p>
 <p> The "Arguments dict" is a dictionary that contains the necessary arguments for the LLM class.</p>
 
 <details>
@@ -178,6 +178,13 @@ result = query("Write a report about xxx.") # Your question here
     <p> Make sure you have prepared your Jiekou.AI API KEY as an env variable <code>JIEKOU_API_KEY</code>. You can create an API Key <a href="https://jiekou.ai/settings/key-management?utm_source=github_deep-searcher">here</a>. </p>
     <pre><code>config.set_provider_config("llm", "JiekouAI", {"model": "claude-sonnet-4-5-20250929"})</code></pre>
     <p> More details about Jiekou.AI: https://docs.jiekou.ai/docs/support/quickstart?utm_source=github_deep-searcher </p>
+</details>
+
+<details>
+  <summary>Example (DeepSeek from Atlas Cloud)</summary>
+    <p> Make sure you have prepared your Atlas Cloud API KEY as an env variable <code>ATLASCLOUD_API_KEY</code>. You can create an API Key <a href="https://www.atlascloud.ai/console?utm_source=github_deep-searcher">here</a>. </p>
+    <pre><code>config.set_provider_config("llm", "AtlasCloud", {"model": "deepseek-ai/deepseek-v4-pro"})</code></pre>
+    <p> More details about Atlas Cloud: https://www.atlascloud.ai/docs?utm_source=github_deep-searcher </p>
 </details>
 
 <details>

--- a/deepsearcher/llm/__init__.py
+++ b/deepsearcher/llm/__init__.py
@@ -1,5 +1,6 @@
 from .aliyun import Aliyun
 from .anthropic_llm import Anthropic
+from .atlascloud import AtlasCloud
 from .azure_openai import AzureOpenAI
 from .bedrock import Bedrock
 from .deepseek import DeepSeek
@@ -34,4 +35,5 @@ __all__ = [
     "Aliyun",
     "WatsonX",
     "JiekouAI",
+    "AtlasCloud",
 ]

--- a/deepsearcher/llm/atlascloud.py
+++ b/deepsearcher/llm/atlascloud.py
@@ -1,0 +1,43 @@
+import os
+from typing import Dict, List
+
+from deepsearcher.llm.base import BaseLLM, ChatResponse
+
+
+class AtlasCloud(BaseLLM):
+    """
+    Atlas Cloud API
+
+    Atlas Cloud is an OpenAI-compatible inference platform, so this provider
+    reuses the OpenAI client with a different base URL.
+
+    Note on the default model: `deepseek-ai/deepseek-v4-pro` is a reasoning
+    model. It spends completion tokens on a hidden chain of thought before the
+    answer, so if a caller passes a small `max_tokens` through kwargs the reply
+    can come back with `finish_reason="length"` and empty content. Leaving
+    `max_tokens` unset (as this provider does) is safe.
+    """
+
+    def __init__(self, model: str = "deepseek-ai/deepseek-v4-pro", **kwargs):
+        from openai import OpenAI as OpenAI_
+
+        self.model = model
+        if "api_key" in kwargs:
+            api_key = kwargs.pop("api_key")
+        else:
+            api_key = os.getenv("ATLASCLOUD_API_KEY")
+        if "base_url" in kwargs:
+            base_url = kwargs.pop("base_url")
+        else:
+            base_url = "https://api.atlascloud.ai/v1"
+        self.client = OpenAI_(api_key=api_key, base_url=base_url, **kwargs)
+
+    def chat(self, messages: List[Dict]) -> ChatResponse:
+        completion = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+        )
+        return ChatResponse(
+            content=completion.choices[0].message.content,
+            total_tokens=completion.usage.total_tokens,
+        )

--- a/docs/configuration/llm.md
+++ b/docs/configuration/llm.md
@@ -27,6 +27,7 @@ config.set_provider_config("llm", "(LLMName)", "(Arguments dict)")
 | **Novita** | Novita AI models | Various options |
 | **IBM watsonx.ai** | IBM Enterprise AI platform | Various options |
 | **Jiekou.AI** | Jiekou.AI models | Claude, OpenAI, Deepseek, Grok, Qwen, etc. |
+| **Atlas Cloud** | OpenAI-compatible inference platform | DeepSeek, Qwen, GLM, Kimi, MiniMax, etc. |
 
 ## 🔍 Provider Examples
 
@@ -43,6 +44,18 @@ config.set_provider_config("llm", "OpenAI", {"model": "o1-mini"})
 config.set_provider_config("llm", "DeepSeek", {"model": "deepseek-reasoner"})
 ```
 *Requires `DEEPSEEK_API_KEY` environment variable*
+
+### Atlas Cloud
+
+```python
+config.set_provider_config("llm", "AtlasCloud", {"model": "deepseek-ai/deepseek-v4-pro"})
+```
+*Requires `ATLASCLOUD_API_KEY` environment variable*
+
+`deepseek-ai/deepseek-v4-pro` is a reasoning model: it spends completion tokens on a hidden chain of
+thought before the answer, so a small `max_tokens` can return an empty `content` with
+`finish_reason="length"`. This provider leaves `max_tokens` unset, which is safe. Non-reasoning ids
+such as `deepseek-ai/DeepSeek-V3.1` are unaffected.
 
 ### IBM WatsonX
 

--- a/tests/llm/test_atlascloud.py
+++ b/tests/llm/test_atlascloud.py
@@ -1,0 +1,165 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import logging
+
+# Disable logging for tests
+logging.disable(logging.CRITICAL)
+
+from deepsearcher.llm import AtlasCloud
+from deepsearcher.llm.base import ChatResponse
+
+
+class TestAtlasCloud(unittest.TestCase):
+    """Tests for the Atlas Cloud LLM provider."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create mock module and components
+        self.mock_openai = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_chat = MagicMock()
+        self.mock_completions = MagicMock()
+        
+        # Set up the mock module structure
+        self.mock_openai.OpenAI = MagicMock(return_value=self.mock_client)
+        self.mock_client.chat = self.mock_chat
+        self.mock_chat.completions = self.mock_completions
+        
+        # Set up mock response
+        self.mock_response = MagicMock()
+        self.mock_choice = MagicMock()
+        self.mock_message = MagicMock()
+        self.mock_usage = MagicMock()
+        
+        self.mock_message.content = "Test response"
+        self.mock_choice.message = self.mock_message
+        self.mock_usage.total_tokens = 100
+        
+        self.mock_response.choices = [self.mock_choice]
+        self.mock_response.usage = self.mock_usage
+        self.mock_completions.create.return_value = self.mock_response
+
+        # Create the module patcher
+        self.module_patcher = patch.dict('sys.modules', {'openai': self.mock_openai})
+        self.module_patcher.start()
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.module_patcher.stop()
+
+    def test_init_default(self):
+        """Test initialization with default parameters."""
+        # Clear environment variables temporarily
+        with patch.dict('os.environ', {}, clear=True):
+            llm = AtlasCloud()
+            # Check that OpenAI client was initialized correctly
+            self.mock_openai.OpenAI.assert_called_once_with(
+                api_key=None,
+                base_url="https://api.atlascloud.ai/v1"
+            )
+            
+            # Check default model
+            self.assertEqual(llm.model, "deepseek-ai/deepseek-v4-pro")
+
+    def test_init_with_api_key_from_env(self):
+        """Test initialization with API key from environment variable."""
+        api_key = "test_api_key_from_env"
+        with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": api_key}):
+            llm = AtlasCloud()
+            self.mock_openai.OpenAI.assert_called_with(
+                api_key=api_key,
+                base_url="https://api.atlascloud.ai/v1"
+            )
+
+    def test_init_with_api_key_parameter(self):
+        """Test initialization with API key as parameter."""
+        with patch.dict('os.environ', {}, clear=True):
+            api_key = "test_api_key_param"
+            llm = AtlasCloud(api_key=api_key)
+            self.mock_openai.OpenAI.assert_called_with(
+                api_key=api_key,
+                base_url="https://api.atlascloud.ai/v1"
+            )
+
+    def test_init_with_custom_model(self):
+        """Test initialization with custom model."""
+        with patch.dict('os.environ', {}, clear=True):
+            model = "deepseek-ai/DeepSeek-V3.1"
+            llm = AtlasCloud(model=model)
+            self.assertEqual(llm.model, model)
+
+    def test_init_with_custom_base_url(self):
+        """Test initialization with custom base URL."""
+        # Clear environment variables temporarily
+        with patch.dict('os.environ', {}, clear=True):
+            base_url = "https://custom.atlascloud.api"
+            llm = AtlasCloud(base_url=base_url)
+            self.mock_openai.OpenAI.assert_called_with(
+                api_key=None,
+                base_url=base_url
+            )
+
+    def test_chat_single_message(self):
+        """Test chat with a single message."""
+        # Create AtlasCloud instance with mocked environment
+        with patch.dict('os.environ', {}, clear=True):
+            llm = AtlasCloud()
+            
+        messages = [{"role": "user", "content": "Hello"}]
+        response = llm.chat(messages)
+
+        # Check that completions.create was called correctly
+        self.mock_completions.create.assert_called_once()
+        call_args = self.mock_completions.create.call_args
+        self.assertEqual(call_args[1]["model"], "deepseek-ai/deepseek-v4-pro")
+        self.assertEqual(call_args[1]["messages"], messages)
+
+        # Check response
+        self.assertIsInstance(response, ChatResponse)
+        self.assertEqual(response.content, "Test response")
+        self.assertEqual(response.total_tokens, 100)
+
+    def test_chat_multiple_messages(self):
+        """Test chat with multiple messages."""
+        # Create AtlasCloud instance with mocked environment
+        with patch.dict('os.environ', {}, clear=True):
+            llm = AtlasCloud()
+            
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"}
+        ]
+        response = llm.chat(messages)
+
+        # Check that completions.create was called correctly
+        self.mock_completions.create.assert_called_once()
+        call_args = self.mock_completions.create.call_args
+        self.assertEqual(call_args[1]["model"], "deepseek-ai/deepseek-v4-pro")
+        self.assertEqual(call_args[1]["messages"], messages)
+
+        # Check response
+        self.assertIsInstance(response, ChatResponse)
+        self.assertEqual(response.content, "Test response")
+        self.assertEqual(response.total_tokens, 100)
+
+    def test_chat_with_error(self):
+        """Test chat when an error occurs."""
+        # Create AtlasCloud instance with mocked environment
+        with patch.dict('os.environ', {}, clear=True):
+            llm = AtlasCloud()
+            
+        # Mock an error response
+        self.mock_completions.create.side_effect = Exception("AtlasCloud API Error")
+
+        messages = [{"role": "user", "content": "Hello"}]
+        with self.assertRaises(Exception) as context:
+            llm.chat(messages)
+
+        self.assertEqual(str(context.exception), "AtlasCloud API Error")
+
+
+if __name__ == "__main__":
+    unittest.main() 


### PR DESCRIPTION
## Summary

Adds **Atlas Cloud** as an LLM provider. It is an OpenAI-compatible inference platform, so the
provider follows the same shape as the other OpenAI-compatible entries already here (Novita, PPIO,
SiliconFlow, Jiekou.AI): reuse the OpenAI client with a different base URL, read the key from
`ATLASCLOUD_API_KEY`, and allow `api_key` / `base_url` overrides through kwargs.

```python
config.set_provider_config("llm", "AtlasCloud", {"model": "deepseek-ai/deepseek-v4-pro"})
```

## Files

- `deepsearcher/llm/atlascloud.py` — `AtlasCloud(BaseLLM)`, default model
  `deepseek-ai/deepseek-v4-pro`, base URL `https://api.atlascloud.ai/v1`.
- `deepsearcher/llm/__init__.py` — import + `__all__`.
- `tests/llm/test_atlascloud.py` — 8 cases mirroring `tests/llm/test_novita.py` (default init, key
  from env, key as parameter, custom model, custom base URL, single- and multi-message chat,
  response mapping).
- `docs/configuration/llm.md` — provider table row + example section.
- `README.md` — `LLMName` list + a `<details>` example block, following the PPIO / Jiekou.AI entries.

## One caveat, documented rather than left to be discovered

The default model is a **reasoning** model: it spends completion tokens on a hidden chain of thought
before writing the answer, so a small `max_tokens` passed through kwargs can come back with
`finish_reason="length"` and an **empty** `content`. This provider leaves `max_tokens` unset, which
is safe — I verified against the live API that a call with no `max_tokens` returns content normally
(`finish_reason=stop`, 32 total tokens for a one-word reply). Non-reasoning ids such as
`deepseek-ai/DeepSeek-V3.1` are unaffected. Both are noted in the docs section.

## Validation

- `pytest tests/llm/` → **146 passed / 10 failed**, up from **138 passed / 10 failed** on a clean
  checkout. The 8 new cases pass; the 10 failures are pre-existing (`test_xai` and friends fail
  identically before this branch — I checked by stashing and re-running).
- Live API check for the reasoning-model note above; the provider itself is unit-tested with a
  mocked `openai` module, exactly like the Novita tests.

No credentials in the diff — the tests use placeholder keys and the docs use the env var name.

<!-- atlas-partnership-start -->
---

### 🤝 Partnership & contact

This PR comes from the **Atlas Cloud** team. Beyond the integration above, we'd love to explore a closer collaboration with **DeepSearcher** — for example **co-marketing** or a featured integration.

If that sounds interesting, reach out anytime:
- 📧 **marketing@atlascloud.ai**
- 🌐 https://www.atlascloud.ai
- 📚 Docs: https://www.atlascloud.ai/docs

And of course, happy to revise this PR to match your project's conventions — just leave a comment. 🙌
<!-- atlas-partnership-end -->
